### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ The official MCP server for [Search1API](https://www.search1api.com/?utm_source=
 1. Register at [Search1API](https://www.search1api.com/?utm_source=mcp)
 2. Get your API key from the dashboard
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/fatwang2-search1api-mcp).
+
 ## Quick Start (Remote MCP)
 
 No installation required. Just configure your MCP client with the remote URL and your API key.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/fatwang2-search1api-mcp)