### PR TITLE
Prepare verified LobeHub MCP listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Search the web using Search1API.
 | `query` | Yes | - | Search query |
 | `max_results` | No | 10 | Number of results |
 | `search_service` | No | google | google, bing, duckduckgo, yahoo, x, reddit, github, youtube, arxiv, wechat, bilibili, imdb, wikipedia |
-| `crawl_results` | No | 0 | Number of results to crawl for full content |
+| `crawl_results` | No | 0 | Number of top results to crawl for full content; each successful crawl adds 1 credit to the base 1-credit search request |
 | `include_sites` | No | [] | Sites to include |
 | `exclude_sites` | No | [] | Sites to exclude |
 | `time_range` | No | - | day, month, year |
@@ -148,7 +148,7 @@ Search for news articles.
 | `query` | Yes | - | Search query |
 | `max_results` | No | 10 | Number of results |
 | `search_service` | No | bing | google, bing, duckduckgo, yahoo, hackernews |
-| `crawl_results` | No | 0 | Number of results to crawl for full content |
+| `crawl_results` | No | 0 | Number of top results to crawl for full content; each successful crawl adds 1 credit to the base 1-credit news request |
 | `include_sites` | No | [] | Sites to include |
 | `exclude_sites` | No | [] | Sites to exclude |
 | `time_range` | No | - | day, month, year |

--- a/README_zh.md
+++ b/README_zh.md
@@ -135,7 +135,7 @@ npx skills add superagents-lab/search1api-cli
 | `query` | 是 | - | 搜索关键词 |
 | `max_results` | 否 | 10 | 返回结果数量 |
 | `search_service` | 否 | google | google、bing、duckduckgo、yahoo、x、reddit、github、youtube、arxiv、wechat、bilibili、imdb、wikipedia |
-| `crawl_results` | 否 | 0 | 需要爬取完整内容的结果数量 |
+| `crawl_results` | 否 | 0 | 抓取完整内容的顶部结果数量；每个成功抓取的页面会在搜索请求基础 1 积分之外增加 1 积分 |
 | `include_sites` | 否 | [] | 限定搜索的网站 |
 | `exclude_sites` | 否 | [] | 排除的网站 |
 | `time_range` | 否 | - | day、month、year |
@@ -148,7 +148,7 @@ npx skills add superagents-lab/search1api-cli
 | `query` | 是 | - | 搜索关键词 |
 | `max_results` | 否 | 10 | 返回结果数量 |
 | `search_service` | 否 | bing | google、bing、duckduckgo、yahoo、hackernews |
-| `crawl_results` | 否 | 0 | 需要爬取完整内容的结果数量 |
+| `crawl_results` | 否 | 0 | 抓取完整内容的顶部结果数量；每个成功抓取的页面会在新闻请求基础 1 积分之外增加 1 积分 |
 | `include_sites` | 否 | [] | 限定搜索的网站 |
 | `exclude_sites` | 否 | [] | 排除的网站 |
 | `time_range` | 否 | - | day、month、year |

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,0 +1,238 @@
+{
+  "identifier": "fatwang2-search1api-mcp",
+  "name": "Search1API MCP Server",
+  "version": "0.3.1",
+  "author": "Search1API",
+  "authorUrl": "https://github.com/superagents-lab",
+  "category": "web-search",
+  "cloudEndpoint": "https://mcp.search1api.com/mcp",
+  "description": "Official Search1API MCP server for web search, news search, page crawling, sitemap discovery, and trending topics. Use the hosted server with OAuth 2.1 or an API key, or run it locally with npm.",
+  "homepage": "https://github.com/superagents-lab/search1api-mcp",
+  "localizations": [
+    {
+      "description": "Search1API 官方 MCP 服务，提供网页搜索、新闻检索、网页抓取、站点地图和热门话题能力。支持通过 OAuth 2.1 或 API Key 使用托管服务，也可通过 npm 本地运行。",
+      "locale": "zh-CN",
+      "name": "Search1API MCP 服务",
+      "tags": [
+        "Search1API",
+        "网页搜索",
+        "新闻检索",
+        "网页抓取",
+        "站点地图",
+        "远程 MCP",
+        "OAuth"
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "uri": "search1api://info",
+      "name": "Search1API Information",
+      "description": "Basic information about Search1API capabilities",
+      "mimeType": "application/json"
+    }
+  ],
+  "tags": [
+    "search1api",
+    "web-search",
+    "news",
+    "web-crawling",
+    "sitemap",
+    "remote-mcp",
+    "oauth"
+  ],
+  "tools": [
+    {
+      "name": "search",
+      "description": "Web search tool",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query, be simple and concise"
+          },
+          "max_results": {
+            "type": "number",
+            "description": "Maximum number of results to return",
+            "default": 10
+          },
+          "search_service": {
+            "type": "string",
+            "description": "Specify the search engine to use. Choose based on your specific needs",
+            "default": "google",
+            "enum": [
+              "google",
+              "bing",
+              "duckduckgo",
+              "yahoo",
+              "x",
+              "reddit",
+              "github",
+              "youtube",
+              "arxiv",
+              "wechat",
+              "bilibili",
+              "imdb",
+              "wikipedia"
+            ]
+          },
+          "crawl_results": {
+            "type": "number",
+            "description": "Number of results to crawl for full webpage content, useful when search result summaries are insufficient for complex queries",
+            "default": 0
+          },
+          "include_sites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of sites to include in search. Only use when you need special results from sites not available in search_service",
+            "default": []
+          },
+          "exclude_sites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of sites to exclude from search. Only use when you need to explicitly filter out specific domains from results",
+            "default": []
+          },
+          "time_range": {
+            "type": "string",
+            "description": "Time range for search results, only use when specific time constraints are required",
+            "enum": [
+              "day",
+              "month",
+              "year"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "news",
+      "description": "News search tool",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query, be simple and concise"
+          },
+          "max_results": {
+            "type": "number",
+            "description": "Maximum number of results to return",
+            "default": 10
+          },
+          "search_service": {
+            "type": "string",
+            "description": "Specify the news engine to use. Choose based on your specific needs",
+            "default": "bing",
+            "enum": [
+              "google",
+              "bing",
+              "duckduckgo",
+              "yahoo",
+              "hackernews"
+            ]
+          },
+          "crawl_results": {
+            "type": "number",
+            "description": "Number of results to crawl for full webpage content, useful when search result summaries are insufficient for complex queries",
+            "default": 0
+          },
+          "include_sites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of sites to include in search. Only use when you need special results from sites not available in search_service",
+            "default": []
+          },
+          "exclude_sites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of sites to exclude from search. Only use when you need to explicitly filter out specific domains from results",
+            "default": []
+          },
+          "time_range": {
+            "type": "string",
+            "description": "Time range for search results, only use when specific time constraints are required",
+            "enum": [
+              "day",
+              "month",
+              "year"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "crawl",
+      "description": "Extract content from URL",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "URL to crawl"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
+    },
+    {
+      "name": "sitemap",
+      "description": "Get all related links from a URL",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "URL to get sitemap"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
+    },
+    {
+      "name": "trending",
+      "description": "Get trending topics from popular platforms",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "search_service": {
+            "type": "string",
+            "description": "Specify the platform to get trending topics from",
+            "enum": [
+              "github",
+              "hackernews"
+            ],
+            "default": "github"
+          },
+          "max_results": {
+            "type": "number",
+            "description": "Maximum number of trending items to return",
+            "default": 10
+          }
+        },
+        "required": [
+          "search_service"
+        ]
+      }
+    }
+  ]
+}

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -5,9 +5,7 @@
   "author": "Search1API",
   "authorUrl": "https://github.com/superagents-lab",
   "category": "web-search",
-  "cloudEndpoint": "https://mcp.search1api.com/mcp",
   "description": "Official Search1API MCP server for web search, news search, page crawling, sitemap discovery, and trending topics. Use the hosted server with OAuth 2.1 or an API key, or run it locally with npm.",
-  "homepage": "https://github.com/superagents-lab/search1api-mcp",
   "localizations": [
     {
       "description": "Search1API 官方 MCP 服务，提供网页搜索、新闻检索、网页抓取、站点地图和热门话题能力。支持通过 OAuth 2.1 或 API Key 使用托管服务，也可通过 npm 本地运行。",
@@ -79,7 +77,7 @@
           },
           "crawl_results": {
             "type": "number",
-            "description": "Number of results to crawl for full webpage content, useful when search result summaries are insufficient for complex queries",
+            "description": "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit search request",
             "default": 0
           },
           "include_sites": {
@@ -142,7 +140,7 @@
           },
           "crawl_results": {
             "type": "number",
-            "description": "Number of results to crawl for full webpage content, useful when search result summaries are insufficient for complex queries",
+            "description": "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit news request",
             "default": 0
           },
           "include_sites": {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,7 +24,7 @@ export const SEARCH_TOOL: Tool = {
       },
       crawl_results: {
         type: "number",
-        description: "Number of results to crawl for full webpage content, useful when search result summaries are insufficient for complex queries",
+        description: "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit search request",
         default: 0
       },
       include_sites: {
@@ -77,7 +77,7 @@ export const NEWS_TOOL: Tool = {
       },
       crawl_results: {
         type: "number",
-        description: "Number of results to crawl for full webpage content, useful when search result summaries are insufficient for complex queries",
+        description: "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit news request",
         default: 0
       },
       include_sites: {

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -66,10 +66,6 @@ test("keeps the LobeHub marketplace manifest aligned with the server", () => {
     "fatwang2-search1api-mcp"
   );
   assert.equal(marketplaceManifest.version, packageJson.version);
-  assert.equal(
-    marketplaceManifest.cloudEndpoint,
-    "https://mcp.search1api.com/mcp"
-  );
   assert.deepEqual(marketplaceManifest.tools, ALL_TOOLS);
   assert.deepEqual(marketplaceManifest.resources, RESOURCES);
   assert.match(marketplaceManifest.description, /OAuth 2\.1/);

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -10,8 +10,12 @@ process.env.SEARCH1API_KEY = "test-key";
 const { createMcpServer } = await import("../build/server.js");
 const { handleToolCall } = await import("../build/tools/handlers.js");
 const { ALL_TOOLS } = await import("../build/tools/index.js");
+const { RESOURCES } = await import("../build/resources.js");
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8")
+);
+const marketplaceManifest = JSON.parse(
+  readFileSync(new URL("../lhm.plugin.json", import.meta.url), "utf8")
 );
 
 test("exports only supported public tools", () => {
@@ -53,5 +57,24 @@ test("rejects retired or unknown tools before making an API request", async () =
       error instanceof McpError &&
       error.code === ErrorCode.InvalidParams &&
       error.message.includes("Unknown tool: reasoning")
+  );
+});
+
+test("keeps the LobeHub marketplace manifest aligned with the server", () => {
+  assert.equal(
+    marketplaceManifest.identifier,
+    "fatwang2-search1api-mcp"
+  );
+  assert.equal(marketplaceManifest.version, packageJson.version);
+  assert.equal(
+    marketplaceManifest.cloudEndpoint,
+    "https://mcp.search1api.com/mcp"
+  );
+  assert.deepEqual(marketplaceManifest.tools, ALL_TOOLS);
+  assert.deepEqual(marketplaceManifest.resources, RESOURCES);
+  assert.match(marketplaceManifest.description, /OAuth 2\.1/);
+  assert.doesNotMatch(
+    JSON.stringify(marketplaceManifest),
+    /reasoning|deepseek/i
   );
 });


### PR DESCRIPTION
## Summary

- add `lhm.plugin.json` for the existing `fatwang2-search1api-mcp` Marketplace entry
- align publishable metadata with the real `0.3.1` release, `superagents-lab` ownership, OAuth 2.1, and current English/Chinese positioning
- declare the five supported tools and the published Search1API resource
- disclose the dynamic credit cost of `crawl_results` in the runtime schema, manifest, and English/Chinese documentation
- add a regression test that keeps the manifest version, tools, and resources aligned with the server and rejects retired reasoning/DeepSeek metadata

## Why

The current LobeHub listing is tied to stale imported metadata: it points at the former repository owner, classifies the server as local-only, contains the retired reasoning capability, and records an imported `1.0.0` that was never released by this project. We want to update the existing Marketplace entry rather than create a duplicate.

This PR only prepares repository-owned metadata. It does not claim or publish the LobeHub listing.

`homepage` and `cloudEndpoint` are intentionally not included in the manifest because the current LobeHub publish endpoint validates but does not store them. The existing listing needs a one-time upstream metadata migration before this manifest is published.

## Validation

- `npm test` — 4 tests passed
- CI — Node 18 and Node 22
- `git diff --check`

## How to review

1. Check the English and Chinese Marketplace positioning and tags.
2. Compare the five declared tools and resource with the runtime exports.
3. Check the `crawl_results` credit warning in the schemas and docs.
4. Confirm the manifest version remains tied to the actual package version.

## Follow-up after merge

1. Ask LobeHub to preserve `fatwang2-search1api-mcp` while migrating its repository, Remote endpoint, service type, and incorrect version history.
2. Claim the corrected existing entry through the LobeHub Market CLI.
3. Publish this manifest as the real version `0.3.1`.
4. Verify the public manifest, page, and LobeHub installation flow.

Do not run `plugin submit`; that could create a duplicate listing.

Linear: https://linear.app/fatwang2/issue/FAT-913/lobehub-外链
