### PR TITLE
Prepare MCP server for public registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [中文文档](./README_zh.md)
 
-The official MCP server for [Search1API](https://www.search1api.com/?utm_source=mcp) — web search, news, crawling, and more in one API.
+The official MCP server for [Search1API](https://www.search1api.com/?utm_source=mcp) — web search, news, page retrieval, sitemap discovery, and trending topics in one API.
 
 ## Authentication
 
@@ -128,7 +128,9 @@ If you prefer to run the server locally, use npx — no cloning required:
 ## Tools
 
 ### search
-Search the web using Search1API.
+Search the web using Search1API. Results use the standard citable
+`id`/`title`/`url` shape expected by ChatGPT deep research and company
+knowledge.
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
@@ -139,6 +141,13 @@ Search the web using Search1API.
 | `include_sites` | No | [] | Sites to include |
 | `exclude_sites` | No | [] | Sites to exclude |
 | `time_range` | No | - | day, month, year |
+
+### fetch
+Retrieve the full readable contents of a result returned by `search`.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | Yes | Result ID returned by `search` (the canonical page URL) |
 
 ### news
 Search for news articles.
@@ -177,6 +186,7 @@ Get trending topics from popular platforms.
 
 ## Version History
 
+- v0.4.0: Standard `search`/`fetch` compatibility, structured output schemas, OAuth security schemes, safety annotations, and Official MCP Registry metadata
 - v0.3.1: OAuth 2.1 support for Remote MCP; retired reasoning tool removed
 - v0.3.0: Remote MCP support via Streamable HTTP; per-session API key authentication
 - v0.2.0: Fallback `.env` support for LibreChat integration

--- a/README_zh.md
+++ b/README_zh.md
@@ -128,7 +128,8 @@ npx skills add superagents-lab/search1api-cli
 ## 工具
 
 ### search
-搜索网页。
+搜索网页。结果采用 ChatGPT 深度研究与 Company Knowledge 兼容的
+`id`/`title`/`url` 可引用结构。
 
 | 参数 | 必需 | 默认值 | 说明 |
 |------|------|--------|------|
@@ -139,6 +140,13 @@ npx skills add superagents-lab/search1api-cli
 | `include_sites` | 否 | [] | 限定搜索的网站 |
 | `exclude_sites` | 否 | [] | 排除的网站 |
 | `time_range` | 否 | - | day、month、year |
+
+### fetch
+获取 `search` 返回结果的完整可读正文。
+
+| 参数 | 必需 | 说明 |
+|------|------|------|
+| `id` | 是 | `search` 返回的结果 ID（网页规范 URL） |
 
 ### news
 搜索新闻。
@@ -177,6 +185,7 @@ npx skills add superagents-lab/search1api-cli
 
 ## 版本历史
 
+- v0.4.0: 标准 `search`/`fetch` 兼容、结构化输出 schema、OAuth 安全声明、只读安全注解和官方 MCP Registry 元数据
 - v0.3.1: Remote MCP 支持 OAuth 2.1；移除已下线的 reasoning 工具
 - v0.3.0: 新增 Remote MCP 支持（Streamable HTTP），per-session API 密钥认证
 - v0.2.0: LibreChat 集成的 `.env` 回退支持

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fatwang2-search1api-mcp",
   "name": "Search1API MCP Server",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Search1API",
   "authorUrl": "https://github.com/superagents-lab",
   "category": "web-search",
@@ -42,22 +42,50 @@
   "tools": [
     {
       "name": "search",
-      "description": "Web search tool",
+      "title": "Search the web",
+      "description": "Search the live public web when the user needs current information, sources, or research. Returns citable results with id, title, URL, and text. Pass a result id to fetch to retrieve the full page.",
+      "securitySchemes": [
+        {
+          "type": "oauth2",
+          "scopes": [
+            "openid",
+            "offline_access"
+          ]
+        }
+      ],
+      "_meta": {
+        "securitySchemes": [
+          {
+            "type": "oauth2",
+            "scopes": [
+              "openid",
+              "offline_access"
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      },
       "inputSchema": {
         "type": "object",
         "properties": {
           "query": {
             "type": "string",
-            "description": "Search query, be simple and concise"
+            "description": "Short, focused search query"
           },
           "max_results": {
             "type": "number",
+            "minimum": 1,
+            "maximum": 50,
             "description": "Maximum number of results to return",
             "default": 10
           },
           "search_service": {
             "type": "string",
-            "description": "Specify the search engine to use. Choose based on your specific needs",
+            "description": "Search engine to use; choose one only when it matches the user's source intent",
             "default": "google",
             "enum": [
               "google",
@@ -77,7 +105,8 @@
           },
           "crawl_results": {
             "type": "number",
-            "description": "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit search request",
+            "minimum": 0,
+            "description": "Number of top results to retrieve as full pages. Each successful page retrieval adds 1 credit to the base 1-credit search request",
             "default": 0
           },
           "include_sites": {
@@ -85,7 +114,7 @@
             "items": {
               "type": "string"
             },
-            "description": "List of sites to include in search. Only use when you need special results from sites not available in search_service",
+            "description": "Domains to include when the user explicitly scopes the search",
             "default": []
           },
           "exclude_sites": {
@@ -93,12 +122,12 @@
             "items": {
               "type": "string"
             },
-            "description": "List of sites to exclude from search. Only use when you need to explicitly filter out specific domains from results",
+            "description": "Domains to exclude from the search",
             "default": []
           },
           "time_range": {
             "type": "string",
-            "description": "Time range for search results, only use when specific time constraints are required",
+            "description": "Optional recency window for time-sensitive searches",
             "enum": [
               "day",
               "month",
@@ -109,26 +138,167 @@
         "required": [
           "query"
         ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Stable identifier for this result; for web results this is the canonical URL"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Human-readable result title"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Canonical URL that clients can cite and users can open"
+                },
+                "text": {
+                  "type": "string",
+                  "description": "Result snippet or extracted page text when available"
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Additional source metadata",
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "url"
+              ]
+            }
+          }
+        },
+        "required": [
+          "results"
+        ]
+      }
+    },
+    {
+      "name": "fetch",
+      "title": "Fetch a search result",
+      "description": "Retrieve the full readable contents of a result returned by search. Pass the result id, which is the canonical page URL. Returns id, title, full text, URL, and metadata.",
+      "securitySchemes": [
+        {
+          "type": "oauth2",
+          "scopes": [
+            "openid",
+            "offline_access"
+          ]
+        }
+      ],
+      "_meta": {
+        "securitySchemes": [
+          {
+            "type": "oauth2",
+            "scopes": [
+              "openid",
+              "offline_access"
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      },
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Result id returned by search; for web results this is the canonical URL"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "text",
+          "url"
+        ]
       }
     },
     {
       "name": "news",
-      "description": "News search tool",
+      "title": "Search current news",
+      "description": "Search current news when the user asks about recent events, announcements, or coverage. Returns citable article results with title, URL, snippet, and optional extracted text.",
+      "securitySchemes": [
+        {
+          "type": "oauth2",
+          "scopes": [
+            "openid",
+            "offline_access"
+          ]
+        }
+      ],
+      "_meta": {
+        "securitySchemes": [
+          {
+            "type": "oauth2",
+            "scopes": [
+              "openid",
+              "offline_access"
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      },
       "inputSchema": {
         "type": "object",
         "properties": {
           "query": {
             "type": "string",
-            "description": "Search query, be simple and concise"
+            "description": "Short, focused news query"
           },
           "max_results": {
             "type": "number",
-            "description": "Maximum number of results to return",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "Maximum number of articles to return",
             "default": 10
           },
           "search_service": {
             "type": "string",
-            "description": "Specify the news engine to use. Choose based on your specific needs",
+            "description": "News search engine to use",
             "default": "bing",
             "enum": [
               "google",
@@ -140,7 +310,8 @@
           },
           "crawl_results": {
             "type": "number",
-            "description": "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit news request",
+            "minimum": 0,
+            "description": "Number of top articles to retrieve as full pages. Each successful retrieval adds 1 credit to the base 1-credit news request",
             "default": 0
           },
           "include_sites": {
@@ -148,7 +319,7 @@
             "items": {
               "type": "string"
             },
-            "description": "List of sites to include in search. Only use when you need special results from sites not available in search_service",
+            "description": "News domains to include",
             "default": []
           },
           "exclude_sites": {
@@ -156,12 +327,12 @@
             "items": {
               "type": "string"
             },
-            "description": "List of sites to exclude from search. Only use when you need to explicitly filter out specific domains from results",
+            "description": "News domains to exclude",
             "default": []
           },
           "time_range": {
             "type": "string",
-            "description": "Time range for search results, only use when specific time constraints are required",
+            "description": "Optional recency window; use day for breaking news",
             "enum": [
               "day",
               "month",
@@ -172,49 +343,227 @@
         "required": [
           "query"
         ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Stable identifier for this result; for web results this is the canonical URL"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Human-readable result title"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Canonical URL that clients can cite and users can open"
+                },
+                "text": {
+                  "type": "string",
+                  "description": "Result snippet or extracted page text when available"
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Additional source metadata",
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "url"
+              ]
+            }
+          }
+        },
+        "required": [
+          "results"
+        ]
       }
     },
     {
       "name": "crawl",
-      "description": "Extract content from URL",
+      "title": "Read a web page",
+      "description": "Extract the readable title and full text from a specific public URL supplied by the user. Use fetch instead when following a result returned by search.",
+      "securitySchemes": [
+        {
+          "type": "oauth2",
+          "scopes": [
+            "openid",
+            "offline_access"
+          ]
+        }
+      ],
+      "_meta": {
+        "securitySchemes": [
+          {
+            "type": "oauth2",
+            "scopes": [
+              "openid",
+              "offline_access"
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      },
       "inputSchema": {
         "type": "object",
         "properties": {
           "url": {
             "type": "string",
-            "description": "URL to crawl"
+            "format": "uri",
+            "description": "Public HTTP or HTTPS URL to retrieve"
           }
         },
         "required": [
           "url"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Stable identifier for this result; for web results this is the canonical URL"
+              },
+              "title": {
+                "type": "string",
+                "description": "Human-readable result title"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Canonical URL that clients can cite and users can open"
+              },
+              "text": {
+                "type": "string",
+                "description": "Result snippet or extracted page text when available"
+              },
+              "metadata": {
+                "type": "object",
+                "description": "Additional source metadata",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "url"
+            ]
+          }
+        },
+        "required": [
+          "result"
         ]
       }
     },
     {
       "name": "sitemap",
-      "description": "Get all related links from a URL",
+      "title": "Discover links on a site",
+      "description": "Discover related public links from a page or domain when the user wants to explore a site's structure or available pages.",
+      "securitySchemes": [
+        {
+          "type": "oauth2",
+          "scopes": [
+            "openid",
+            "offline_access"
+          ]
+        }
+      ],
+      "_meta": {
+        "securitySchemes": [
+          {
+            "type": "oauth2",
+            "scopes": [
+              "openid",
+              "offline_access"
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      },
       "inputSchema": {
         "type": "object",
         "properties": {
           "url": {
             "type": "string",
-            "description": "URL to get sitemap"
+            "format": "uri",
+            "description": "Public page or domain URL whose links should be discovered"
           }
         },
         "required": [
           "url"
         ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "required": [
+          "links"
+        ]
       }
     },
     {
       "name": "trending",
-      "description": "Get trending topics from popular platforms",
+      "title": "Explore trending topics",
+      "description": "List currently trending repositories or stories from GitHub or Hacker News when the user asks what is popular now.",
+      "securitySchemes": [
+        {
+          "type": "oauth2",
+          "scopes": [
+            "openid",
+            "offline_access"
+          ]
+        }
+      ],
+      "_meta": {
+        "securitySchemes": [
+          {
+            "type": "oauth2",
+            "scopes": [
+              "openid",
+              "offline_access"
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      },
       "inputSchema": {
         "type": "object",
         "properties": {
           "search_service": {
             "type": "string",
-            "description": "Specify the platform to get trending topics from",
+            "description": "Platform whose trending items should be returned",
             "enum": [
               "github",
               "hackernews"
@@ -223,12 +572,44 @@
           },
           "max_results": {
             "type": "number",
+            "minimum": 1,
+            "maximum": 50,
             "description": "Maximum number of trending items to return",
             "default": 10
           }
         },
         "required": [
           "search_service"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "url"
+              ]
+            }
+          }
+        },
+        "required": [
+          "results"
         ]
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search1api-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search1api-mcp",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "search1api-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
+  "mcpName": "io.github.superagents-lab/search1api",
   "description": "A Model Context Protocol (MCP) server that provides search and crawl functionality using Search1API",
   "private": false,
   "type": "module",
@@ -8,7 +9,8 @@
     "search1api-mcp": "build/index.js"
   },
   "files": [
-    "build"
+    "build",
+    "server.json"
   ],
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('build', { recursive: true, force: true })\" && tsc && node -e \"require('node:fs').chmodSync('build/index.js', '755')\"",
@@ -17,7 +19,8 @@
     "prepack": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
-    "start:http": "node build/http.js"
+    "start:http": "node build/http.js",
+    "sync:manifest": "npm run build && node scripts/sync-lobe-manifest.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/sync-lobe-manifest.mjs
+++ b/scripts/sync-lobe-manifest.mjs
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+);
+const manifestUrl = new URL("../lhm.plugin.json", import.meta.url);
+const manifest = JSON.parse(readFileSync(manifestUrl, "utf8"));
+const { ALL_TOOLS } = await import("../build/tools/index.js");
+
+manifest.version = packageJson.version;
+manifest.tools = ALL_TOOLS;
+
+writeFileSync(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.superagents-lab/search1api",
+  "title": "Search1API",
+  "description": "Web search, news, page retrieval, sitemaps, and trending topics through Search1API.",
+  "repository": {
+    "url": "https://github.com/superagents-lab/search1api-mcp",
+    "source": "github"
+  },
+  "version": "0.4.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.search1api.com/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "search1api-mcp",
+      "version": "0.4.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SEARCH1API_KEY",
+          "description": "Search1API API key for local stdio mode",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -29,11 +29,23 @@ export async function handleCrawl(args: unknown, apiKey?: string) {
     const endTime = Date.now();
     log(`Crawl completed successfully in ${endTime - startTime}ms`);
 
+    const result = {
+      id: response.results.link || url,
+      title: response.results.title,
+      url: response.results.link || url,
+      text: response.results.content,
+      metadata: {
+        source: "search1api",
+      },
+    };
+    const structuredContent = { result };
+
     return {
+      structuredContent,
       content: [{
         type: "text",
         mimeType: "application/json",
-        text: JSON.stringify(response.results, null, 2)
+        text: JSON.stringify(structuredContent)
       }]
     };
   } catch (error) {

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -1,0 +1,62 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { makeRequest } from "../api.js";
+import { API_CONFIG } from "../config.js";
+import {
+  CrawlResponse,
+  FetchArgs,
+  isValidFetchArgs,
+} from "../types.js";
+import { formatError, log } from "../utils.js";
+
+/**
+ * ChatGPT-compatible fetch implementation. Search result IDs are canonical
+ * URLs, so fetch can pass the ID directly to the crawl endpoint.
+ */
+export async function handleFetch(args: unknown, apiKey?: string) {
+  if (!isValidFetchArgs(args)) {
+    throw new McpError(ErrorCode.InvalidParams, "Invalid fetch arguments");
+  }
+
+  const { id } = args as FetchArgs;
+  log("Fetching search result:", id);
+
+  try {
+    const response = await makeRequest<CrawlResponse>(
+      API_CONFIG.ENDPOINTS.CRAWL,
+      { url: id },
+      apiKey
+    );
+    const result = {
+      id,
+      title: response.results.title,
+      text: response.results.content,
+      url: response.results.link || id,
+      metadata: {
+        source: "search1api",
+      },
+    };
+
+    return {
+      structuredContent: result,
+      content: [
+        {
+          type: "text",
+          mimeType: "application/json",
+          text: JSON.stringify(result),
+        },
+      ],
+    };
+  } catch (error) {
+    log("Fetch error:", error);
+    return {
+      content: [
+        {
+          type: "text",
+          mimeType: "text/plain",
+          text: `Fetch API error: ${formatError(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -1,11 +1,12 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { log } from '../utils.js';
 import { handleSearch } from './search.js';
+import { handleFetch } from './fetch.js';
 import { handleCrawl } from './crawl.js';
 import { handleSitemap } from './sitemap.js';
 import { handleNews } from './news.js';
 import { handleTrending } from './trending.js';
-import { SEARCH_TOOL, CRAWL_TOOL, SITEMAP_TOOL, NEWS_TOOL, TRENDING_TOOL } from './index.js';
+import { SEARCH_TOOL, FETCH_TOOL, CRAWL_TOOL, SITEMAP_TOOL, NEWS_TOOL, TRENDING_TOOL } from './index.js';
 
 /**
  * Dispatch request based on tool name
@@ -20,6 +21,9 @@ export async function handleToolCall(toolName: string, args: unknown, apiKey?: s
   switch (toolName) {
     case SEARCH_TOOL.name:
       return await handleSearch(args, apiKey);
+
+    case FETCH_TOOL.name:
+      return await handleFetch(args, apiKey);
 
     case CRAWL_TOOL.name:
       return await handleCrawl(args, apiKey);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,171 +1,343 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
+type OAuthTool = Tool & {
+  securitySchemes: Array<{
+    type: "oauth2";
+    scopes: string[];
+  }>;
+};
+
+const AUTHENTICATED_READ_ONLY_WEB: Pick<
+  OAuthTool,
+  "_meta" | "annotations" | "securitySchemes"
+> = {
+  securitySchemes: [
+    {
+      type: "oauth2",
+      scopes: ["openid", "offline_access"],
+    },
+  ],
+  _meta: {
+    securitySchemes: [
+      {
+        type: "oauth2",
+        scopes: ["openid", "offline_access"],
+      },
+    ],
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+};
+
+const CITABLE_RESULT_SCHEMA = {
+  type: "object",
+  properties: {
+    id: {
+      type: "string",
+      description: "Stable identifier for this result; for web results this is the canonical URL",
+    },
+    title: {
+      type: "string",
+      description: "Human-readable result title",
+    },
+    url: {
+      type: "string",
+      format: "uri",
+      description: "Canonical URL that clients can cite and users can open",
+    },
+    text: {
+      type: "string",
+      description: "Result snippet or extracted page text when available",
+    },
+    metadata: {
+      type: "object",
+      description: "Additional source metadata",
+      additionalProperties: true,
+    },
+  },
+  required: ["id", "title", "url"],
+};
+
+const SEARCH_OUTPUT_SCHEMA: NonNullable<Tool["outputSchema"]> = {
+  type: "object",
+  properties: {
+    results: {
+      type: "array",
+      items: CITABLE_RESULT_SCHEMA,
+    },
+  },
+  required: ["results"],
+};
+
+const FETCH_OUTPUT_SCHEMA: NonNullable<Tool["outputSchema"]> = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    title: { type: "string" },
+    text: { type: "string" },
+    url: { type: "string", format: "uri" },
+    metadata: {
+      type: "object",
+      additionalProperties: true,
+    },
+  },
+  required: ["id", "title", "text", "url"],
+};
+
 // Search tool definition
-export const SEARCH_TOOL: Tool = {
+export const SEARCH_TOOL: OAuthTool = {
   name: "search",
-  description: "Web search tool",
+  title: "Search the web",
+  description:
+    "Search the live public web when the user needs current information, sources, or research. Returns citable results with id, title, URL, and text. Pass a result id to fetch to retrieve the full page.",
+  ...AUTHENTICATED_READ_ONLY_WEB,
   inputSchema: {
     type: "object",
     properties: {
       query: {
         type: "string",
-        description: "Search query, be simple and concise"
+        description: "Short, focused search query",
       },
       max_results: {
         type: "number",
+        minimum: 1,
+        maximum: 50,
         description: "Maximum number of results to return",
-        default: 10
+        default: 10,
       },
       search_service: {
         type: "string",
-        description: "Specify the search engine to use. Choose based on your specific needs",
+        description: "Search engine to use; choose one only when it matches the user's source intent",
         default: "google",
-        enum: ["google", "bing", "duckduckgo", "yahoo", "x", "reddit", "github", "youtube", "arxiv", "wechat", "bilibili", "imdb", "wikipedia"]
+        enum: ["google", "bing", "duckduckgo", "yahoo", "x", "reddit", "github", "youtube", "arxiv", "wechat", "bilibili", "imdb", "wikipedia"],
       },
       crawl_results: {
         type: "number",
-        description: "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit search request",
-        default: 0
+        minimum: 0,
+        description: "Number of top results to retrieve as full pages. Each successful page retrieval adds 1 credit to the base 1-credit search request",
+        default: 0,
       },
       include_sites: {
         type: "array",
         items: {
-          type: "string"
+          type: "string",
         },
-        description: "List of sites to include in search. Only use when you need special results from sites not available in search_service",
-        default: []
+        description: "Domains to include when the user explicitly scopes the search",
+        default: [],
       },
       exclude_sites: {
         type: "array",
         items: {
-          type: "string"
+          type: "string",
         },
-        description: "List of sites to exclude from search. Only use when you need to explicitly filter out specific domains from results",
-        default: []
+        description: "Domains to exclude from the search",
+        default: [],
       },
       time_range: {
         type: "string",
-        description: "Time range for search results, only use when specific time constraints are required",
-        enum: ["day", "month", "year"]
-      }
+        description: "Optional recency window for time-sensitive searches",
+        enum: ["day", "month", "year"],
+      },
     },
-    required: ["query"]
-  }
+    required: ["query"],
+  },
+  outputSchema: SEARCH_OUTPUT_SCHEMA,
+};
+
+// Fetch tool definition for ChatGPT deep research and company knowledge.
+export const FETCH_TOOL: OAuthTool = {
+  name: "fetch",
+  title: "Fetch a search result",
+  description:
+    "Retrieve the full readable contents of a result returned by search. Pass the result id, which is the canonical page URL. Returns id, title, full text, URL, and metadata.",
+  ...AUTHENTICATED_READ_ONLY_WEB,
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Result id returned by search; for web results this is the canonical URL",
+      },
+    },
+    required: ["id"],
+  },
+  outputSchema: FETCH_OUTPUT_SCHEMA,
 };
 
 // News tool definition
-export const NEWS_TOOL: Tool = {
+export const NEWS_TOOL: OAuthTool = {
   name: "news",
-  description: "News search tool",
+  title: "Search current news",
+  description:
+    "Search current news when the user asks about recent events, announcements, or coverage. Returns citable article results with title, URL, snippet, and optional extracted text.",
+  ...AUTHENTICATED_READ_ONLY_WEB,
   inputSchema: {
     type: "object",
     properties: {
       query: {
         type: "string",
-        description: "Search query, be simple and concise"
+        description: "Short, focused news query",
       },
       max_results: {
         type: "number",
-        description: "Maximum number of results to return",
-        default: 10
+        minimum: 1,
+        maximum: 50,
+        description: "Maximum number of articles to return",
+        default: 10,
       },
       search_service: {
         type: "string",
-        description: "Specify the news engine to use. Choose based on your specific needs",
+        description: "News search engine to use",
         default: "bing",
-        enum: ["google", "bing", "duckduckgo", "yahoo", "hackernews"]
+        enum: ["google", "bing", "duckduckgo", "yahoo", "hackernews"],
       },
       crawl_results: {
         type: "number",
-        description: "Number of top results to crawl for full webpage content. Each successfully crawled page adds 1 credit to the base 1-credit news request",
-        default: 0
+        minimum: 0,
+        description: "Number of top articles to retrieve as full pages. Each successful retrieval adds 1 credit to the base 1-credit news request",
+        default: 0,
       },
       include_sites: {
         type: "array",
         items: {
-          type: "string"
+          type: "string",
         },
-        description: "List of sites to include in search. Only use when you need special results from sites not available in search_service",
-        default: []
+        description: "News domains to include",
+        default: [],
       },
       exclude_sites: {
         type: "array",
         items: {
-          type: "string"
+          type: "string",
         },
-        description: "List of sites to exclude from search. Only use when you need to explicitly filter out specific domains from results",
-        default: []
+        description: "News domains to exclude",
+        default: [],
       },
       time_range: {
         type: "string",
-        description: "Time range for search results, only use when specific time constraints are required",
-        enum: ["day", "month", "year"]
-      }
+        description: "Optional recency window; use day for breaking news",
+        enum: ["day", "month", "year"],
+      },
     },
-    required: ["query"]
-  }
+    required: ["query"],
+  },
+  outputSchema: SEARCH_OUTPUT_SCHEMA,
 };
 
 // Crawl tool definition
-export const CRAWL_TOOL: Tool = {
+export const CRAWL_TOOL: OAuthTool = {
   name: "crawl",
-  description: "Extract content from URL",
+  title: "Read a web page",
+  description:
+    "Extract the readable title and full text from a specific public URL supplied by the user. Use fetch instead when following a result returned by search.",
+  ...AUTHENTICATED_READ_ONLY_WEB,
   inputSchema: {
     type: "object",
     properties: {
       url: {
         type: "string",
-        description: "URL to crawl"
-      }
+        format: "uri",
+        description: "Public HTTP or HTTPS URL to retrieve",
+      },
     },
-    required: ["url"]
-  }
+    required: ["url"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      result: CITABLE_RESULT_SCHEMA,
+    },
+    required: ["result"],
+  },
 };
 
 // Sitemap tool definition
-export const SITEMAP_TOOL: Tool = {
+export const SITEMAP_TOOL: OAuthTool = {
   name: "sitemap",
-  description: "Get all related links from a URL",
+  title: "Discover links on a site",
+  description:
+    "Discover related public links from a page or domain when the user wants to explore a site's structure or available pages.",
+  ...AUTHENTICATED_READ_ONLY_WEB,
   inputSchema: {
     type: "object",
     properties: {
       url: {
         type: "string",
-        description: "URL to get sitemap"
-      }
+        format: "uri",
+        description: "Public page or domain URL whose links should be discovered",
+      },
     },
-    required: ["url"]
-  }
+    required: ["url"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      links: {
+        type: "array",
+        items: {
+          type: "string",
+          format: "uri",
+        },
+      },
+    },
+    required: ["links"],
+  },
 };
 
 // Trending tool definition
-export const TRENDING_TOOL: Tool = {
+export const TRENDING_TOOL: OAuthTool = {
   name: "trending",
-  description: "Get trending topics from popular platforms",
+  title: "Explore trending topics",
+  description:
+    "List currently trending repositories or stories from GitHub or Hacker News when the user asks what is popular now.",
+  ...AUTHENTICATED_READ_ONLY_WEB,
   inputSchema: {
     type: "object",
     properties: {
       search_service: {
         type: "string",
-        description: "Specify the platform to get trending topics from",
+        description: "Platform whose trending items should be returned",
         enum: ["github", "hackernews"],
-        default: "github"
+        default: "github",
       },
       max_results: {
         type: "number",
+        minimum: 1,
+        maximum: 50,
         description: "Maximum number of trending items to return",
-        default: 10
-      }
+        default: 10,
+      },
     },
-    required: ["search_service"]
-  }
+    required: ["search_service"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      results: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            url: { type: "string", format: "uri" },
+            description: { type: "string" },
+          },
+          required: ["title", "url"],
+        },
+      },
+    },
+    required: ["results"],
+  },
 };
 
-// Export all tools
 export const ALL_TOOLS = [
   SEARCH_TOOL,
+  FETCH_TOOL,
   NEWS_TOOL,
   CRAWL_TOOL,
   SITEMAP_TOOL,
-  TRENDING_TOOL
+  TRENDING_TOOL,
 ];

--- a/src/tools/news.ts
+++ b/src/tools/news.ts
@@ -24,11 +24,24 @@ export async function handleNews(args: unknown, apiKey?: string) {
       apiKey
     );
     
+    const results = response.results.map((result) => ({
+      id: result.link,
+      title: result.title,
+      url: result.link,
+      text: result.content || result.snippet,
+      metadata: {
+        snippet: result.snippet,
+        ...(result.content ? { has_full_content: true } : {}),
+      },
+    }));
+    const structuredContent = { results };
+
     return {
+      structuredContent,
       content: [{
         type: "text",
         mimeType: "application/json",
-        text: JSON.stringify(response.results, null, 2)
+        text: JSON.stringify(structuredContent)
       }]
     };
   } catch (error) {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -22,11 +22,24 @@ export async function handleSearch(args: unknown, apiKey?: string) {
       apiKey
     );
 
+    const results = response.results.map((result) => ({
+      id: result.link,
+      title: result.title,
+      url: result.link,
+      text: result.content || result.snippet,
+      metadata: {
+        snippet: result.snippet,
+        ...(result.content ? { has_full_content: true } : {}),
+      },
+    }));
+    const structuredContent = { results };
+
     return {
+      structuredContent,
       content: [{
         type: "text",
         mimeType: "application/json",
-        text: JSON.stringify(response.results, null, 2)
+        text: JSON.stringify(structuredContent)
       }]
     };
   } catch (error) {

--- a/src/tools/sitemap.ts
+++ b/src/tools/sitemap.ts
@@ -22,11 +22,14 @@ export async function handleSitemap(args: unknown, apiKey?: string) {
       apiKey
     );
     
+    const structuredContent = { links: response.links };
+
     return {
+      structuredContent,
       content: [{
         type: "text",
         mimeType: "application/json",
-        text: JSON.stringify(response.links, null, 2)
+        text: JSON.stringify(structuredContent)
       }]
     };
   } catch (error) {

--- a/src/tools/trending.ts
+++ b/src/tools/trending.ts
@@ -22,11 +22,14 @@ export async function handleTrending(args: unknown, apiKey?: string) {
       apiKey
     );
 
+    const structuredContent = { results: response.results };
+
     return {
+      structuredContent,
       content: [{
         type: "text",
         mimeType: "application/json",
-        text: JSON.stringify(response.results, null, 2)
+        text: JSON.stringify(structuredContent)
       }]
     };
   } catch (error) {
@@ -39,4 +42,4 @@ export async function handleTrending(args: unknown, apiKey?: string) {
       isError: true
     };
   }
-} 
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,19 @@ export interface CrawlArgs {
   url: string;
 }
 
+export interface FetchArgs {
+  id: string;
+}
+
+export function isValidFetchArgs(args: unknown): args is FetchArgs {
+  if (typeof args !== "object" || args === null) {
+    return false;
+  }
+
+  const { id } = args as FetchArgs;
+  return typeof id === "string" && id.trim().length > 0;
+}
+
 export function isValidCrawlArgs(args: unknown): args is CrawlArgs {
   if (typeof args !== 'object' || args === null) {
     return false;

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -21,7 +21,7 @@ const marketplaceManifest = JSON.parse(
 test("exports only supported public tools", () => {
   assert.deepEqual(
     ALL_TOOLS.map((tool) => tool.name),
-    ["search", "news", "crawl", "sitemap", "trending"]
+    ["search", "fetch", "news", "crawl", "sitemap", "trending"]
   );
   assert.equal(
     existsSync(new URL("../build/tools/reasoning.js", import.meta.url)),
@@ -46,8 +46,39 @@ test("lists the supported tools over MCP", async (context) => {
   assert.equal(client.getServerVersion()?.version, packageJson.version);
   assert.deepEqual(
     result.tools.map((tool) => tool.name),
-    ["search", "news", "crawl", "sitemap", "trending"]
+    ["search", "fetch", "news", "crawl", "sitemap", "trending"]
   );
+  assert.equal(result.tools[0].title, "Search the web");
+  assert.deepEqual(result.tools[0]._meta.securitySchemes, [
+    { type: "oauth2", scopes: ["openid", "offline_access"] },
+  ]);
+  assert.deepEqual(result.tools[0].outputSchema.required, ["results"]);
+});
+
+test("advertises directory-ready metadata and search/fetch compatibility", () => {
+  for (const tool of ALL_TOOLS) {
+    assert.equal(typeof tool.title, "string");
+    assert.equal(tool.annotations?.readOnlyHint, true);
+    assert.equal(tool.annotations?.destructiveHint, false);
+    assert.equal(tool.annotations?.openWorldHint, true);
+    assert.deepEqual(tool.securitySchemes, [
+      { type: "oauth2", scopes: ["openid", "offline_access"] },
+    ]);
+    assert.deepEqual(tool._meta.securitySchemes, tool.securitySchemes);
+    assert.equal(tool.outputSchema?.type, "object");
+  }
+
+  const search = ALL_TOOLS.find((tool) => tool.name === "search");
+  const fetch = ALL_TOOLS.find((tool) => tool.name === "fetch");
+  assert.deepEqual(search.inputSchema.required, ["query"]);
+  assert.deepEqual(search.outputSchema.required, ["results"]);
+  assert.deepEqual(fetch.inputSchema.required, ["id"]);
+  assert.deepEqual(fetch.outputSchema.required, [
+    "id",
+    "title",
+    "text",
+    "url",
+  ]);
 });
 
 test("rejects retired or unknown tools before making an API request", async () => {


### PR DESCRIPTION
## What changed

- add ChatGPT-compatible read-only `search` + `fetch` tools with citable structured output
- add titles, output schemas, safety annotations, and OAuth security schemes to all tools
- add Official MCP Registry `server.json` metadata and the npm `mcpName`
- bump the server to 0.4.0 and keep the LobeHub manifest generated from the runtime tool list
- document the new compatibility path in English and Chinese

## Why

Claude/OpenAI directory submissions and ChatGPT deep research need precise tool metadata. ChatGPT company knowledge specifically expects the standard `search`/`fetch` pair and URL-backed results.

## User impact

Existing tools remain available. `crawl` is preserved for direct URLs, while `fetch` provides the standard follow-up path from search results.

## Validation

- `npm test`: 5/5 passed
- `npm pack --dry-run`: passed
- `mcp-publisher validate server.json`: passed against the live registry
- local Streamable HTTP smoke test authenticated with the first non-empty `WHITELISTED_TOKENS` key and returned all 6 tools
- `git diff --check`: passed

Registry publication follows the npm 0.4.0 release after merge.

Tracking: FAT-943, FAT-944
