### PR TITLE
Upgrade Search1API MCP to the 2026-07-28 protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ npx skills add superagents-lab/search1api-cli
 
 ## Local Mode (stdio)
 
-If you prefer to run the server locally, use npx — no cloning required:
+If you prefer to run the server locally, use Node.js 20 or newer with npx — no cloning required:
 
 ```json
 {
@@ -124,6 +124,11 @@ If you prefer to run the server locally, use npx — no cloning required:
   }
 }
 ```
+
+For self-hosted HTTP deployments behind a proxy, add any internal hostnames
+that reach the Node.js process to the comma-separated `MCP_ALLOWED_HOSTS`
+environment variable. `mcp.search1api.com` and localhost addresses are allowed
+by default.
 
 ## Tools
 
@@ -186,6 +191,7 @@ Get trending topics from popular platforms.
 
 ## Version History
 
+- v0.5.0: MCP 2026-07-28 support with automatic protocol negotiation; stateless compatibility for 2025-era HTTP clients; request-level authentication
 - v0.4.0: Standard `search`/`fetch` compatibility, structured output schemas, OAuth security schemes, safety annotations, and Official MCP Registry metadata
 - v0.3.1: OAuth 2.1 support for Remote MCP; retired reasoning tool removed
 - v0.3.0: Remote MCP support via Streamable HTTP; per-session API key authentication

--- a/README_zh.md
+++ b/README_zh.md
@@ -109,7 +109,7 @@ npx skills add superagents-lab/search1api-cli
 
 ## 本地模式（stdio）
 
-如果你更倾向于在本地运行，通过 npx 即可使用，无需克隆仓库：
+如果你更倾向于在本地运行，请使用 Node.js 20 或更高版本；通过 npx 即可使用，无需克隆仓库：
 
 ```json
 {
@@ -124,6 +124,10 @@ npx skills add superagents-lab/search1api-cli
   }
 }
 ```
+
+自行部署 HTTP 服务并使用反向代理时，请通过逗号分隔的
+`MCP_ALLOWED_HOSTS` 环境变量添加会到达 Node.js 进程的内部主机名。
+默认允许 `mcp.search1api.com` 和 localhost 地址。
 
 ## 工具
 
@@ -185,6 +189,7 @@ npx skills add superagents-lab/search1api-cli
 
 ## 版本历史
 
+- v0.5.0: 支持 MCP 2026-07-28 与自动协议协商；通过无状态回退兼容 2025 版本 HTTP 客户端；改为请求级认证
 - v0.4.0: 标准 `search`/`fetch` 兼容、结构化输出 schema、OAuth 安全声明、只读安全注解和官方 MCP Registry 元数据
 - v0.3.1: Remote MCP 支持 OAuth 2.1；移除已下线的 reasoning 工具
 - v0.3.0: 新增 Remote MCP 支持（Streamable HTTP），per-session API 密钥认证

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fatwang2-search1api-mcp",
   "name": "Search1API MCP Server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Search1API",
   "authorUrl": "https://github.com/superagents-lab",
   "category": "web-search",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "search1api-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search1api-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "dotenv": "^16.6.1",
         "express": "^4.22.2"
       },
@@ -17,12 +18,13 @@
         "search1api-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@types/express": "^5.0.6",
         "@types/node": "^20.19.43",
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -37,359 +39,69 @@
         "hono": "^4"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
+        "@modelcontextprotocol/core": "2.0.0",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
         "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
+        "hono": {
           "optional": true
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+    "node_modules/@modelcontextprotocol/server": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">=20"
       }
     },
     "node_modules/@types/body-parser": {
@@ -501,39 +213,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/array-flatten": {
@@ -655,27 +334,11 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -804,6 +467,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -816,6 +480,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -866,70 +531,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -1054,6 +655,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
       "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1096,15 +698,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1114,38 +707,22 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
       "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1231,15 +808,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1264,15 +832,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1286,6 +845,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1301,6 +861,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -1342,95 +903,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/router/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -1514,6 +986,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1526,6 +999,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1686,6 +1160,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1697,12 +1172,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -1710,15 +1179,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search1api-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mcpName": "io.github.superagents-lab/search1api",
   "description": "A Model Context Protocol (MCP) server that provides search and crawl functionality using Search1API",
   "private": false,
@@ -23,11 +23,13 @@
     "sync:manifest": "npm run build && node scripts/sync-lobe-manifest.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "dotenv": "^16.6.1",
     "express": "^4.22.2"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/express": "^5.0.6",
     "@types/node": "^20.19.43",
     "typescript": "^5.9.3"
@@ -54,6 +56,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/superagents-lab/search1api-mcp",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.5.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "search1api-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,13 +5,13 @@ import { log } from './utils.js';
  * Unified API request function
  * @param endpoint API endpoint
  * @param data Request data
- * @param apiKey Optional per-session API key (falls back to global API_KEY)
+ * @param apiKey Optional request credential (falls back to global API_KEY)
  * @returns API response
  */
 export async function makeRequest<T>(endpoint: string, data: any, apiKey?: string): Promise<T> {
   const key = apiKey || API_KEY;
   if (!key) {
-    throw new Error("API key is required. Provide SEARCH1API_KEY or pass apiKey per-session.");
+    throw new Error("API key is required. Provide SEARCH1API_KEY or pass apiKey explicitly.");
   }
 
   const startTime = Date.now();

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ if (!API_KEY) {
 
 // Final check
 if (!API_KEY) {
-  log('SEARCH1API_KEY not found. Stdio mode requires it; HTTP mode uses per-session keys.');
+  log('SEARCH1API_KEY not found. Stdio mode requires it; HTTP mode uses per-request credentials.');
 } else {
   log('API key located successfully.');
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
-import { createHash, randomUUID } from "node:crypto";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { createHash } from "node:crypto";
+import { pathToFileURL } from "node:url";
+import type { Server as HttpServer } from "node:http";
+import {
+  hostHeaderValidation,
+  toNodeHandler,
+} from "@modelcontextprotocol/node";
+import {
+  createMcpHandler,
+  type AuthInfo,
+  type McpHttpHandler,
+} from "@modelcontextprotocol/server";
 import express from "express";
 import { createMcpServer } from "./server.js";
-import { log } from "./utils.js";
-
-const app = express();
+import { formatError, log } from "./utils.js";
 
 const API_BASE_URL =
   process.env.SEARCH1API_API_URL || "https://api.search1api.com";
@@ -15,7 +22,7 @@ const MCP_RESOURCE = "https://mcp.search1api.com/mcp";
 const MCP_RESOURCE_METADATA =
   "https://mcp.search1api.com/.well-known/oauth-protected-resource/mcp";
 
-type AuthenticatedCredential = {
+export type AuthenticatedCredential = {
   credential: string;
   principal: string;
 };
@@ -26,89 +33,25 @@ type UsageIdentity = {
   client_id?: string | null;
 };
 
-type McpSession = {
-  transport: StreamableHTTPServerTransport;
-  server: Server;
-  principal: string;
-  credential: { current: string };
+export type CredentialValidator = (
+  credential: string
+) => Promise<AuthenticatedCredential | null>;
+
+export type HttpAppOptions = {
+  validateCredential?: CredentialValidator;
+  allowedHostnames?: string[];
 };
 
-// The service root is documentation, not an MCP transport endpoint. Keep
-// query parameters so bookmarked campaign/support links remain attributable.
-app.get("/", (req, res) => {
-  const target = new URL("https://www.search1api.com/docs/integrations/mcp");
-  for (const [key, value] of Object.entries(req.query)) {
-    if (typeof value === "string") {
-      target.searchParams.append(key, value);
-    }
-  }
-  res.redirect(301, target.toString());
-});
-
-const protectedResourceMetadata = {
-  resource: MCP_RESOURCE,
-  authorization_servers: [AUTHORIZATION_SERVER],
-  bearer_methods_supported: ["header"],
-  scopes_supported: ["openid", "offline_access"],
-  resource_documentation: "https://www.search1api.com/auth.md",
+export type Search1ApiHttpApp = {
+  app: express.Express;
+  mcpHandler: McpHttpHandler;
+  close(): Promise<void>;
 };
 
-app.get(
-  [
-    "/.well-known/oauth-protected-resource",
-    "/.well-known/oauth-protected-resource/mcp",
-  ],
-  (_req, res) => {
-    res.type("application/json").json(protectedResourceMetadata);
-  }
-);
-
-app.get("/.well-known/oauth-authorization-server", (_req, res) => {
-  res.redirect(
-    302,
-    `${AUTHORIZATION_SERVER}/.well-known/oauth-authorization-server`
-  );
-});
-
-app.use(express.json());
-
-// Session storage: sessionId -> MCP transport, server, and authenticated
-// principal. The credential itself is mutable so a refreshed OAuth access
-// token can continue the same session after it is validated.
-const sessions = new Map<string, McpSession>();
-
-/** Extract a Bearer credential, retaining the legacy query-key fallback. */
-function extractCredential(req: express.Request): string | undefined {
-  const auth = req.headers.authorization;
-  if (auth?.startsWith("Bearer ")) {
-    return auth.slice(7).trim() || undefined;
-  }
-  const queryKey = req.query.apiKey;
-  if (typeof queryKey === "string" && queryKey.trim()) {
-    return queryKey.trim();
-  }
-  return undefined;
-}
-
-function challenge(
-  res: express.Response,
-  message: string,
-  error?: "invalid_token"
-) {
-  const errorParameter = error ? `, error="${error}"` : "";
-  res.set(
-    "WWW-Authenticate",
-    `Bearer resource_metadata="${MCP_RESOURCE_METADATA}"${errorParameter}`
-  );
-  res.status(401).json({
-    jsonrpc: "2.0",
-    error: { code: -32001, message },
-    id: null,
-  });
-}
-
-/** Validate both Clerk OAuth tokens and legacy Search1API API keys at the API. */
-async function validateCredential(
+/**
+ * Validate both Clerk OAuth tokens and legacy Search1API API keys at the API.
+ */
+export async function validateCredential(
   credential: string
 ): Promise<AuthenticatedCredential | null> {
   const response = await fetch(`${API_BASE_URL}/usage`, {
@@ -141,10 +84,187 @@ async function validateCredential(
   return { credential, principal };
 }
 
+/**
+ * Build the HTTP application without starting a listener.
+ *
+ * A single v2 handler serves the 2026-07-28 protocol and the SDK's default
+ * stateless 2025 fallback. Authentication is validated for every exchange,
+ * so no credential or principal is retained in a server-side MCP session.
+ */
+export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
+  const app = express();
+  const credentialValidator = options.validateCredential ?? validateCredential;
+  const allowedHostnames =
+    options.allowedHostnames ?? configuredAllowedHostnames();
+  const validateHost = hostHeaderValidation(allowedHostnames);
+
+  const mcpHandler = createMcpHandler(
+    ({ authInfo }) => createMcpServer(authInfo?.token),
+    {
+      legacy: "stateless",
+      onerror: (error) => log("MCP handler error:", error),
+    }
+  );
+  const nodeHandler = toNodeHandler(mcpHandler, {
+    onerror: (error) => log("MCP Node adapter error:", error),
+  });
+
+  app.use((req, res, next) => {
+    if (!validateHost(req, res)) {
+      return;
+    }
+    next();
+  });
+
+  // The service root is documentation, not an MCP transport endpoint. Keep
+  // query parameters so bookmarked campaign/support links remain attributable.
+  app.get("/", (req, res) => {
+    const target = new URL("https://www.search1api.com/docs/integrations/mcp");
+    for (const [key, value] of Object.entries(req.query)) {
+      if (typeof value === "string") {
+        target.searchParams.append(key, value);
+      }
+    }
+    res.redirect(301, target.toString());
+  });
+
+  const protectedResourceMetadata = {
+    resource: MCP_RESOURCE,
+    authorization_servers: [AUTHORIZATION_SERVER],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["openid", "offline_access"],
+    resource_documentation: "https://www.search1api.com/auth.md",
+  };
+
+  app.get(
+    [
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/mcp",
+    ],
+    (_req, res) => {
+      res.type("application/json").json(protectedResourceMetadata);
+    }
+  );
+
+  app.get("/.well-known/oauth-authorization-server", (_req, res) => {
+    res.redirect(
+      302,
+      `${AUTHORIZATION_SERVER}/.well-known/oauth-authorization-server`
+    );
+  });
+
+  app.use(express.json());
+
+  app.all("/mcp", async (req, res) => {
+    const authenticated = await authenticateMcpRequest(
+      req,
+      res,
+      credentialValidator
+    );
+    if (!authenticated) {
+      return;
+    }
+
+    const authInfo: AuthInfo = {
+      token: authenticated.credential,
+      clientId: authenticated.principal,
+      scopes: [],
+    };
+    (req as express.Request & { auth?: AuthInfo }).auth = authInfo;
+
+    await nodeHandler(req, res, req.body);
+  });
+
+  return {
+    app,
+    mcpHandler,
+    close: () => mcpHandler.close(),
+  };
+}
+
+function configuredAllowedHostnames(): string[] {
+  const configured = (process.env.MCP_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((hostname) => hostname.trim())
+    .filter(Boolean);
+
+  return [
+    ...new Set([
+      "mcp.search1api.com",
+      "localhost",
+      "127.0.0.1",
+      "[::1]",
+      ...configured,
+    ]),
+  ];
+}
+
+/** Start the production HTTP listener. */
+export function startHttpServer(
+  port = Number.parseInt(process.env.PORT || "3000", 10)
+): Search1ApiHttpApp & { httpServer: HttpServer } {
+  const httpApp = createHttpApp();
+  const httpServer = httpApp.app.listen(port, () => {
+    log(
+      `Search1API MCP HTTP server listening on http://localhost:${port}/mcp`
+    );
+  });
+
+  let closing = false;
+  const shutdown = async () => {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    log("Shutting down HTTP server...");
+    await httpApp.close();
+    if (httpServer.listening) {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  };
+
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+
+  return { ...httpApp, httpServer, close: shutdown };
+}
+
+/** Extract a Bearer credential, retaining the legacy query-key fallback. */
+function extractCredential(req: express.Request): string | undefined {
+  const auth = req.headers.authorization;
+  if (auth?.startsWith("Bearer ")) {
+    return auth.slice(7).trim() || undefined;
+  }
+  const queryKey = req.query.apiKey;
+  if (typeof queryKey === "string" && queryKey.trim()) {
+    return queryKey.trim();
+  }
+  return undefined;
+}
+
+function challenge(
+  res: express.Response,
+  message: string,
+  error?: "invalid_token"
+) {
+  const errorParameter = error ? `, error="${error}"` : "";
+  res.set(
+    "WWW-Authenticate",
+    `Bearer resource_metadata="${MCP_RESOURCE_METADATA}"${errorParameter}`
+  );
+  res.status(401).json({
+    jsonrpc: "2.0",
+    error: { code: -32001, message },
+    id: null,
+  });
+}
+
 async function authenticateMcpRequest(
   req: express.Request,
   res: express.Response,
-  expectedPrincipal?: string
+  credentialValidator: CredentialValidator
 ): Promise<AuthenticatedCredential | null> {
   const credential = extractCredential(req);
   if (!credential) {
@@ -157,7 +277,7 @@ async function authenticateMcpRequest(
 
   let authenticated: AuthenticatedCredential | null;
   try {
-    authenticated = await validateCredential(credential);
+    authenticated = await credentialValidator(credential);
   } catch (error) {
     log("Credential validation failed:", error);
     res.status(503).json({
@@ -172,163 +292,31 @@ async function authenticateMcpRequest(
   }
 
   if (!authenticated) {
-    challenge(res, "The Bearer credential is invalid or expired.", "invalid_token");
-    return null;
-  }
-  if (expectedPrincipal && authenticated.principal !== expectedPrincipal) {
-    res.status(403).json({
-      jsonrpc: "2.0",
-      error: {
-        code: -32003,
-        message: "The credential does not belong to this MCP session.",
-      },
-      id: null,
-    });
+    challenge(
+      res,
+      "The Bearer credential is invalid or expired.",
+      "invalid_token"
+    );
     return null;
   }
   return authenticated;
 }
 
-function isInitializeRequest(body: unknown): boolean {
-  if (Array.isArray(body)) {
-    return body.some(
-      (message) =>
-        typeof message === "object" &&
-        message !== null &&
-        (message as Record<string, unknown>).method === "initialize"
-    );
-  }
-  return (
-    typeof body === "object" &&
-    body !== null &&
-    (body as Record<string, unknown>).method === "initialize"
-  );
+function installGlobalErrorLogging() {
+  process.on("uncaughtException", (error) => {
+    log("Uncaught exception:", error);
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    log("Unhandled rejection:", reason);
+  });
 }
 
-// Handle POST /mcp - initialize or route to an existing session.
-app.post("/mcp", async (req, res) => {
-  const sessionId = req.headers["mcp-session-id"] as string | undefined;
+const isMain =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
 
-  if (sessionId && sessions.has(sessionId)) {
-    const session = sessions.get(sessionId)!;
-    const authenticated = await authenticateMcpRequest(
-      req,
-      res,
-      session.principal
-    );
-    if (!authenticated) {
-      return;
-    }
-    session.credential.current = authenticated.credential;
-    await session.transport.handleRequest(req, res, req.body);
-    return;
-  }
-
-  if (!sessionId && isInitializeRequest(req.body)) {
-    const authenticated = await authenticateMcpRequest(req, res);
-    if (!authenticated) {
-      return;
-    }
-    const credential = { current: authenticated.credential };
-
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (sid) => {
-        sessions.set(sid, {
-          transport,
-          server,
-          principal: authenticated.principal,
-          credential,
-        });
-        log(`Session created: ${sid}`);
-      },
-    });
-
-    transport.onclose = () => {
-      if (transport.sessionId) {
-        sessions.delete(transport.sessionId);
-        log(`Session closed: ${transport.sessionId}`);
-      }
-    };
-
-    const server = createMcpServer(() => credential.current);
-    await server.connect(transport);
-    await transport.handleRequest(req, res, req.body);
-    return;
-  }
-
-  res.status(400).json({
-    jsonrpc: "2.0",
-    error: {
-      code: -32600,
-      message: "Bad request: no valid session or not an initialize request",
-    },
-    id: null,
-  });
-});
-
-// Handle GET /mcp - SSE stream for an existing session.
-app.get("/mcp", async (req, res) => {
-  const sessionId = req.headers["mcp-session-id"] as string;
-  if (!sessionId || !sessions.has(sessionId)) {
-    res.status(400).json({
-      jsonrpc: "2.0",
-      error: { code: -32600, message: "Invalid or missing session ID" },
-      id: null,
-    });
-    return;
-  }
-
-  const session = sessions.get(sessionId)!;
-  const authenticated = await authenticateMcpRequest(
-    req,
-    res,
-    session.principal
-  );
-  if (!authenticated) {
-    return;
-  }
-  session.credential.current = authenticated.credential;
-  await session.transport.handleRequest(req, res);
-});
-
-// Handle DELETE /mcp - authenticated session termination.
-app.delete("/mcp", async (req, res) => {
-  const sessionId = req.headers["mcp-session-id"] as string;
-  if (sessionId && sessions.has(sessionId)) {
-    const session = sessions.get(sessionId)!;
-    const authenticated = await authenticateMcpRequest(
-      req,
-      res,
-      session.principal
-    );
-    if (!authenticated) {
-      return;
-    }
-    await session.transport.handleRequest(req, res);
-    await session.server.close();
-    sessions.delete(sessionId);
-    log(`Session terminated: ${sessionId}`);
-    return;
-  }
-
-  res.status(400).json({
-    jsonrpc: "2.0",
-    error: { code: -32600, message: "Invalid or missing session ID" },
-    id: null,
-  });
-});
-
-const PORT = parseInt(process.env.PORT || "3000", 10);
-
-app.listen(PORT, () => {
-  log(`Search1API MCP HTTP server listening on http://localhost:${PORT}/mcp`);
-});
-
-process.on("uncaughtException", (error) => {
-  log("Uncaught exception:", error);
-});
-
-process.on("unhandledRejection", (reason) => {
-  log("Unhandled rejection:", reason);
-});
+if (isMain) {
+  installGlobalErrorLogging();
+  startHttpServer();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,45 +1,39 @@
 #!/usr/bin/env node
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { log } from "./utils.js";
-import { createMcpServer } from "./server.js";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { API_KEY } from "./config.js";
+import { createMcpServer } from "./server.js";
+import { log } from "./utils.js";
 
-/**
- * Main function - Program entry point (stdio mode)
- */
-async function main() {
-  // Stdio mode requires API key at startup
+function main() {
   if (!API_KEY) {
     log("SEARCH1API_KEY environment variable is not set");
     process.exit(1);
   }
 
-  try {
-    log("Starting Search1API MCP server (stdio mode)");
-    const server = createMcpServer();
-    const transport = new StdioServerTransport();
+  log("Starting Search1API MCP server (stdio mode)");
+  const handle = serveStdio(() => createMcpServer(API_KEY), {
+    legacy: "serve",
+    onerror: (error) => log("MCP stdio error:", error),
+  });
+  log("Server started successfully");
 
-    await server.connect(transport);
-    log("Server started successfully");
+  let closing = false;
+  const exitHandler = async () => {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    log("Shutting down server...");
+    await handle.close();
+    process.exit(0);
+  };
 
-    // Handle process exit signals
-    const exitHandler = async () => {
-      log("Shutting down server...");
-      await server.close();
-      process.exit(0);
-    };
-
-    process.on("SIGINT", exitHandler);
-    process.on("SIGTERM", exitHandler);
-    process.on("SIGUSR1", exitHandler);
-    process.on("SIGUSR2", exitHandler);
-  } catch (error) {
-    log("Failed to start server:", error);
-    process.exit(1);
-  }
+  process.once("SIGINT", exitHandler);
+  process.once("SIGTERM", exitHandler);
+  process.once("SIGUSR1", exitHandler);
+  process.once("SIGUSR2", exitHandler);
 }
 
-// Handle global errors
 process.on("uncaughtException", (error) => {
   log("Uncaught exception:", error);
 });
@@ -48,8 +42,9 @@ process.on("unhandledRejection", (reason) => {
   log("Unhandled rejection:", reason);
 });
 
-// Start program
-main().catch((error) => {
-  log("Fatal error:", error);
+try {
+  main();
+} catch (error) {
+  log("Failed to start server:", error);
   process.exit(1);
-});
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,6 +1,5 @@
-import { McpError, ErrorCode, Resource } from "@modelcontextprotocol/sdk/types.js";
-import { log } from './utils.js';
-import { API_CONFIG } from './config.js';
+import { ResourceNotFoundError, type Resource } from "@modelcontextprotocol/server";
+import { log } from "./utils.js";
 
 /**
  * Define the default search query result resource
@@ -31,15 +30,12 @@ export function handleListResources(): Resource[] {
  */
 export function handleReadResource(resourceUri: string): Resource {
   log(`Handling read resource request for ${resourceUri}`);
-  
+
   const resource = RESOURCES.find((r) => r.uri === resourceUri);
-  
+
   if (!resource) {
-    throw new McpError(
-      ErrorCode.InvalidRequest,
-      `Resource not found: ${resourceUri}`
-    );
+    throw new ResourceNotFoundError(resourceUri);
   }
-  
+
   return resource;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,114 +1,104 @@
 import {
-  Server
-} from "@modelcontextprotocol/sdk/server/index.js";
-import {
-  McpError,
-  ErrorCode,
-  CallToolRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
-  ListToolsRequestSchema
-} from "@modelcontextprotocol/sdk/types.js";
+  INTERNAL_ERROR,
+  McpServer,
+  ProtocolError,
+  fromJsonSchema,
+  type JsonSchemaType,
+} from "@modelcontextprotocol/server";
+import { handleReadResource, RESOURCES } from "./resources.js";
 import { handleToolCall } from "./tools/handlers.js";
-import { log, formatError } from "./utils.js";
-import { handleListResources, handleReadResource } from "./resources.js";
 import { ALL_TOOLS } from "./tools/index.js";
+import { formatError, log } from "./utils.js";
 import { PACKAGE_VERSION } from "./version.js";
 
+type CredentialProvider = string | (() => string | undefined);
+
 /**
- * Create and configure MCP server
- * @param credential Optional per-session credential or mutable credential
- * provider (used in HTTP mode so refreshed OAuth tokens can replace expired
- * access tokens without changing the MCP session principal)
- * @returns Server instance ready to be connected to a transport
+ * Create one transport-neutral MCP server instance.
+ *
+ * The v2 serving entries call this factory once per modern HTTP exchange,
+ * once per stateless legacy HTTP request, or once per stdio connection.
  */
-export function createMcpServer(
-  credential?: string | (() => string | undefined)
-): Server {
+export function createMcpServer(credential?: CredentialProvider): McpServer {
   log("Creating Search1API MCP server");
 
-  const server = new Server({
+  const server = new McpServer({
     name: "search1api-server",
-    version: PACKAGE_VERSION
-  }, {
-    capabilities: {
-      resources: {},
-      tools: {}
-    }
+    version: PACKAGE_VERSION,
   });
 
-  setupRequestHandlers(server, credential);
+  for (const tool of ALL_TOOLS) {
+    const inputSchema = fromJsonSchema<Record<string, unknown>>(
+      tool.inputSchema as JsonSchemaType
+    );
+    const outputSchema = tool.outputSchema
+      ? fromJsonSchema<Record<string, unknown>>(
+          tool.outputSchema as JsonSchemaType
+        )
+      : undefined;
+
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema,
+        ...(outputSchema ? { outputSchema } : {}),
+        annotations: tool.annotations,
+        _meta: tool._meta,
+      },
+      async (args) => {
+        try {
+          const bearerCredential =
+            typeof credential === "function" ? credential() : credential;
+          log(`Tool call received: ${tool.name}`);
+          return await handleToolCall(tool.name, args, bearerCredential);
+        } catch (error) {
+          throw normalizeProtocolError(`handling tool call ${tool.name}`, error);
+        }
+      }
+    );
+  }
+
+  for (const resource of RESOURCES) {
+    server.registerResource(
+      resource.name,
+      resource.uri,
+      {
+        description: resource.description,
+        mimeType: resource.mimeType,
+      },
+      async (uri) => {
+        try {
+          const result = handleReadResource(uri.href);
+          return {
+            contents: [
+              {
+                uri: uri.href,
+                mimeType: result.mimeType || "application/json",
+                text: JSON.stringify(result),
+              },
+            ],
+          };
+        } catch (error) {
+          throw normalizeProtocolError("reading resource", error);
+        }
+      }
+    );
+  }
 
   return server;
 }
 
-/**
- * Helper function to handle errors uniformly
- */
-function handleError(context: string, error: unknown): never {
+function normalizeProtocolError(context: string, error: unknown): ProtocolError {
   log(`Error ${context}:`, error);
 
-  if (error instanceof McpError) {
-    throw error;
+  if (error instanceof ProtocolError) {
+    return error;
   }
 
-  throw new McpError(
-    ErrorCode.InternalError,
+  return new ProtocolError(
+    INTERNAL_ERROR,
     `${context}: ${formatError(error)}`
   );
-}
-
-/**
- * Set up server request handlers
- */
-function setupRequestHandlers(
-  server: Server,
-  credential?: string | (() => string | undefined)
-) {
-  // Handle tool calls
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    try {
-      const toolName = request.params.name;
-      const toolArgs = request.params.arguments;
-
-      log(`Tool call received: ${toolName}`);
-      const bearerCredential =
-        typeof credential === "function" ? credential() : credential;
-      return await handleToolCall(toolName, toolArgs, bearerCredential);
-    } catch (error) {
-      handleError("handling tool call", error);
-    }
-  });
-
-  // Handle resource listing
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    try {
-      return { resources: handleListResources() };
-    } catch (error) {
-      handleError("listing resources", error);
-    }
-  });
-
-  // Handle resource reading
-  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-    try {
-      const resourceUri = request.params.uri;
-      const resource = handleReadResource(resourceUri);
-
-      return {
-        contents: [{
-          uri: resourceUri,
-          mimeType: resource.mimeType || "application/json",
-          text: JSON.stringify(resource)
-        }]
-      };
-    } catch (error) {
-      handleError("reading resource", error);
-    }
-  });
-
-  // Handle tool listing
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: ALL_TOOLS };
-  });
 }

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -2,17 +2,21 @@ import { CrawlArgs, CrawlResponse, isValidCrawlArgs } from '../types.js';
 import { makeRequest } from '../api.js';
 import { formatError, log } from '../utils.js';
 import { API_CONFIG } from '../config.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
 
 /**
  * Implementation of the crawl tool
  */
-export async function handleCrawl(args: unknown, apiKey?: string) {
+export async function handleCrawl(
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   if (!isValidCrawlArgs(args)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      "Invalid crawl arguments"
-    );
+    throw new ProtocolError(INVALID_PARAMS, "Invalid crawl arguments");
   }
 
   const { url } = args;
@@ -44,7 +48,6 @@ export async function handleCrawl(args: unknown, apiKey?: string) {
       structuredContent,
       content: [{
         type: "text",
-        mimeType: "application/json",
         text: JSON.stringify(structuredContent)
       }]
     };
@@ -53,7 +56,6 @@ export async function handleCrawl(args: unknown, apiKey?: string) {
     return {
       content: [{
         type: "text",
-        mimeType: "text/plain",
         text: `Crawl API error: ${formatError(error)}`
       }],
       isError: true

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -1,4 +1,8 @@
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
 import { makeRequest } from "../api.js";
 import { API_CONFIG } from "../config.js";
 import {
@@ -12,9 +16,12 @@ import { formatError, log } from "../utils.js";
  * ChatGPT-compatible fetch implementation. Search result IDs are canonical
  * URLs, so fetch can pass the ID directly to the crawl endpoint.
  */
-export async function handleFetch(args: unknown, apiKey?: string) {
+export async function handleFetch(
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   if (!isValidFetchArgs(args)) {
-    throw new McpError(ErrorCode.InvalidParams, "Invalid fetch arguments");
+    throw new ProtocolError(INVALID_PARAMS, "Invalid fetch arguments");
   }
 
   const { id } = args as FetchArgs;
@@ -41,7 +48,6 @@ export async function handleFetch(args: unknown, apiKey?: string) {
       content: [
         {
           type: "text",
-          mimeType: "application/json",
           text: JSON.stringify(result),
         },
       ],
@@ -52,7 +58,6 @@ export async function handleFetch(args: unknown, apiKey?: string) {
       content: [
         {
           type: "text",
-          mimeType: "text/plain",
           text: `Fetch API error: ${formatError(error)}`,
         },
       ],

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -1,21 +1,36 @@
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { log } from '../utils.js';
-import { handleSearch } from './search.js';
-import { handleFetch } from './fetch.js';
-import { handleCrawl } from './crawl.js';
-import { handleSitemap } from './sitemap.js';
-import { handleNews } from './news.js';
-import { handleTrending } from './trending.js';
-import { SEARCH_TOOL, FETCH_TOOL, CRAWL_TOOL, SITEMAP_TOOL, NEWS_TOOL, TRENDING_TOOL } from './index.js';
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
+import { log } from "../utils.js";
+import { handleSearch } from "./search.js";
+import { handleFetch } from "./fetch.js";
+import { handleCrawl } from "./crawl.js";
+import { handleSitemap } from "./sitemap.js";
+import { handleNews } from "./news.js";
+import { handleTrending } from "./trending.js";
+import {
+  SEARCH_TOOL,
+  FETCH_TOOL,
+  CRAWL_TOOL,
+  SITEMAP_TOOL,
+  NEWS_TOOL,
+  TRENDING_TOOL,
+} from "./index.js";
 
 /**
  * Dispatch request based on tool name
  * @param toolName Name of the tool
  * @param args Tool parameters
- * @param apiKey Optional per-session API key
+ * @param apiKey Optional request credential
  * @returns Tool processing result
  */
-export async function handleToolCall(toolName: string, args: unknown, apiKey?: string) {
+export async function handleToolCall(
+  toolName: string,
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   log(`Handling tool call: ${toolName}`);
 
   switch (toolName) {
@@ -39,9 +54,6 @@ export async function handleToolCall(toolName: string, args: unknown, apiKey?: s
 
     default:
       log(`Unknown tool: ${toolName}`);
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Unknown tool: ${toolName}`
-      );
+      throw new ProtocolError(INVALID_PARAMS, `Unknown tool: ${toolName}`);
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
-import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/server";
 
 type OAuthTool = Tool & {
   securitySchemes: Array<{

--- a/src/tools/news.ts
+++ b/src/tools/news.ts
@@ -2,17 +2,21 @@ import { NewsArgs, NewsResponse, isValidNewsArgs } from '../types.js';
 import { makeRequest } from '../api.js';
 import { formatError, log } from '../utils.js';
 import { API_CONFIG } from '../config.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
 
 /**
  * Implementation of the news search tool
  */
-export async function handleNews(args: unknown, apiKey?: string) {
+export async function handleNews(
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   if (!isValidNewsArgs(args)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      "Invalid news search arguments"
-    );
+    throw new ProtocolError(INVALID_PARAMS, "Invalid news search arguments");
   }
 
   log("Processing news search with query:", (args as NewsArgs).query);
@@ -40,7 +44,6 @@ export async function handleNews(args: unknown, apiKey?: string) {
       structuredContent,
       content: [{
         type: "text",
-        mimeType: "application/json",
         text: JSON.stringify(structuredContent)
       }]
     };
@@ -49,7 +52,6 @@ export async function handleNews(args: unknown, apiKey?: string) {
     return {
       content: [{
         type: "text",
-        mimeType: "text/plain",
         text: `News API error: ${formatError(error)}`
       }],
       isError: true

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2,17 +2,21 @@ import { SearchArgs, SearchResponse, isValidSearchArgs } from '../types.js';
 import { makeRequest } from '../api.js';
 import { formatError } from '../utils.js';
 import { API_CONFIG } from '../config.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
 
 /**
  * Implementation of the search tool
  */
-export async function handleSearch(args: unknown, apiKey?: string) {
+export async function handleSearch(
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   if (!isValidSearchArgs(args)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      "Invalid search arguments"
-    );
+    throw new ProtocolError(INVALID_PARAMS, "Invalid search arguments");
   }
 
   try {
@@ -38,7 +42,6 @@ export async function handleSearch(args: unknown, apiKey?: string) {
       structuredContent,
       content: [{
         type: "text",
-        mimeType: "application/json",
         text: JSON.stringify(structuredContent)
       }]
     };
@@ -46,7 +49,6 @@ export async function handleSearch(args: unknown, apiKey?: string) {
     return {
       content: [{
         type: "text",
-        mimeType: "text/plain",
         text: `Search API error: ${formatError(error)}`
       }],
       isError: true

--- a/src/tools/sitemap.ts
+++ b/src/tools/sitemap.ts
@@ -2,17 +2,21 @@ import { SitemapArgs, SitemapResponse, isValidSitemapArgs } from '../types.js';
 import { makeRequest } from '../api.js';
 import { formatError } from '../utils.js';
 import { API_CONFIG } from '../config.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
 
 /**
  * Implementation of the sitemap tool
  */
-export async function handleSitemap(args: unknown, apiKey?: string) {
+export async function handleSitemap(
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   if (!isValidSitemapArgs(args)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      "Invalid sitemap arguments"
-    );
+    throw new ProtocolError(INVALID_PARAMS, "Invalid sitemap arguments");
   }
 
   try {
@@ -28,7 +32,6 @@ export async function handleSitemap(args: unknown, apiKey?: string) {
       structuredContent,
       content: [{
         type: "text",
-        mimeType: "application/json",
         text: JSON.stringify(structuredContent)
       }]
     };
@@ -36,7 +39,6 @@ export async function handleSitemap(args: unknown, apiKey?: string) {
     return {
       content: [{
         type: "text",
-        mimeType: "text/plain",
         text: `Sitemap API error: ${formatError(error)}`
       }],
       isError: true

--- a/src/tools/trending.ts
+++ b/src/tools/trending.ts
@@ -2,17 +2,21 @@ import { TrendingArgs, TrendingResponse, isValidTrendingArgs } from '../types.js
 import { makeRequest } from '../api.js';
 import { formatError } from '../utils.js';
 import { API_CONFIG } from '../config.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+  type CallToolResult,
+} from "@modelcontextprotocol/server";
 
 /**
  * Implementation of the trending tool
  */
-export async function handleTrending(args: unknown, apiKey?: string) {
+export async function handleTrending(
+  args: unknown,
+  apiKey?: string
+): Promise<CallToolResult> {
   if (!isValidTrendingArgs(args)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      "Invalid trending arguments"
-    );
+    throw new ProtocolError(INVALID_PARAMS, "Invalid trending arguments");
   }
 
   try {
@@ -28,7 +32,6 @@ export async function handleTrending(args: unknown, apiKey?: string) {
       structuredContent,
       content: [{
         type: "text",
-        mimeType: "application/json",
         text: JSON.stringify(structuredContent)
       }]
     };
@@ -36,7 +39,6 @@ export async function handleTrending(args: unknown, apiKey?: string) {
     return {
       content: [{
         type: "text",
-        mimeType: "text/plain",
         text: `Trending API error: ${formatError(error)}`
       }],
       isError: true

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -1,12 +1,21 @@
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
+import http from "node:http";
 import test from "node:test";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  Client,
+  InMemoryTransport,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import {
+  INVALID_PARAMS,
+  ProtocolError,
+} from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 
 process.env.SEARCH1API_KEY = "test-key";
 
+const { createHttpApp } = await import("../build/http.js");
 const { createMcpServer } = await import("../build/server.js");
 const { handleToolCall } = await import("../build/tools/handlers.js");
 const { ALL_TOOLS } = await import("../build/tools/index.js");
@@ -18,10 +27,19 @@ const marketplaceManifest = JSON.parse(
   readFileSync(new URL("../lhm.plugin.json", import.meta.url), "utf8")
 );
 
+const EXPECTED_TOOLS = [
+  "search",
+  "fetch",
+  "news",
+  "crawl",
+  "sitemap",
+  "trending",
+];
+
 test("exports only supported public tools", () => {
   assert.deepEqual(
     ALL_TOOLS.map((tool) => tool.name),
-    ["search", "fetch", "news", "crawl", "sitemap", "trending"]
+    EXPECTED_TOOLS
   );
   assert.equal(
     existsSync(new URL("../build/tools/reasoning.js", import.meta.url)),
@@ -29,24 +47,28 @@ test("exports only supported public tools", () => {
   );
 });
 
-test("lists the supported tools over MCP", async (context) => {
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const server = createMcpServer("test-key");
-  const client = new Client({ name: "search1api-mcp-test", version: "1.0.0" });
+test("serves MCP 2026-07-28 clients over HTTP", async (context) => {
+  const testServer = await startTestHttpServer();
+  const client = new Client(
+    { name: "search1api-modern-test", version: "1.0.0" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } }
+  );
+  const transport = createAuthenticatedTransport(testServer.url);
 
   context.after(async () => {
     await client.close();
-    await server.close();
+    await testServer.close();
   });
 
-  await server.connect(serverTransport);
-  await client.connect(clientTransport);
-
+  await client.connect(transport);
   const result = await client.listTools();
+
+  assert.equal(client.getProtocolEra(), "modern");
+  assert.equal(client.getNegotiatedProtocolVersion(), "2026-07-28");
   assert.equal(client.getServerVersion()?.version, packageJson.version);
   assert.deepEqual(
     result.tools.map((tool) => tool.name),
-    ["search", "fetch", "news", "crawl", "sitemap", "trending"]
+    EXPECTED_TOOLS
   );
   assert.equal(result.tools[0].title, "Search the web");
   assert.deepEqual(result.tools[0]._meta.securitySchemes, [
@@ -81,12 +103,130 @@ test("advertises directory-ready metadata and search/fetch compatibility", () =>
   ]);
 });
 
+test("keeps 2025-era clients working through the stateless fallback", async (context) => {
+  const testServer = await startTestHttpServer();
+  const client = new Client(
+    { name: "search1api-legacy-test", version: "1.0.0" },
+    { versionNegotiation: { mode: "legacy" } }
+  );
+  const transport = createAuthenticatedTransport(testServer.url);
+
+  context.after(async () => {
+    await client.close();
+    await testServer.close();
+  });
+
+  await client.connect(transport);
+  const result = await client.listTools();
+
+  assert.equal(client.getProtocolEra(), "legacy");
+  assert.equal(client.getServerVersion()?.version, packageJson.version);
+  assert.deepEqual(
+    result.tools.map((tool) => tool.name),
+    EXPECTED_TOOLS
+  );
+});
+
+test("serves MCP 2026-07-28 clients over the stdio entry", async (context) => {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const serverHandle = serveStdio(() => createMcpServer("test-key"), {
+    transport: serverTransport,
+  });
+  const client = new Client(
+    { name: "search1api-stdio-test", version: "1.0.0" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } }
+  );
+
+  context.after(async () => {
+    await client.close();
+    await serverHandle.close();
+  });
+
+  await client.connect(clientTransport);
+  const result = await client.listTools();
+
+  assert.equal(client.getProtocolEra(), "modern");
+  assert.deepEqual(
+    result.tools.map((tool) => tool.name),
+    EXPECTED_TOOLS
+  );
+});
+
+test("authenticates every MCP HTTP request before protocol handling", async (context) => {
+  const validatedCredentials = [];
+  const testServer = await startTestHttpServer(async (credential) => {
+    validatedCredentials.push(credential);
+    if (credential === "invalid") {
+      return null;
+    }
+    if (credential === "outage") {
+      throw new Error("validation unavailable");
+    }
+    return { credential, principal: `test:${credential}` };
+  });
+
+  context.after(() => testServer.close());
+
+  const request = (authorization) =>
+    fetch(testServer.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(authorization ? { authorization } : {}),
+      },
+      body: "{}",
+    });
+
+  const missing = await request();
+  assert.equal(missing.status, 401);
+  assert.match(
+    missing.headers.get("www-authenticate") ?? "",
+    /resource_metadata=/
+  );
+
+  const invalid = await request("Bearer invalid");
+  assert.equal(invalid.status, 401);
+  assert.match(
+    invalid.headers.get("www-authenticate") ?? "",
+    /error="invalid_token"/
+  );
+
+  const unavailable = await request("Bearer outage");
+  assert.equal(unavailable.status, 503);
+  assert.deepEqual(validatedCredentials, ["invalid", "outage"]);
+});
+
+test("rejects DNS rebinding attempts before MCP handling", async (context) => {
+  let validationCalls = 0;
+  const testServer = await startTestHttpServer(async (credential) => {
+    validationCalls += 1;
+    return { credential, principal: `test:${credential}` };
+  });
+
+  context.after(() => testServer.close());
+
+  const response = await rawHttpRequest(testServer.url, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-key",
+      "content-type": "application/json",
+      host: "attacker.example",
+      origin: "https://attacker.example",
+    },
+    body: "{}",
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.equal(validationCalls, 0);
+});
+
 test("rejects retired or unknown tools before making an API request", async () => {
   await assert.rejects(
     handleToolCall("reasoning", {}),
     (error) =>
-      error instanceof McpError &&
-      error.code === ErrorCode.InvalidParams &&
+      error instanceof ProtocolError &&
+      error.code === INVALID_PARAMS &&
       error.message.includes("Unknown tool: reasoning")
   );
 });
@@ -105,3 +245,58 @@ test("keeps the LobeHub marketplace manifest aligned with the server", () => {
     /reasoning|deepseek/i
   );
 });
+
+function createAuthenticatedTransport(url) {
+  return new StreamableHTTPClientTransport(url, {
+    requestInit: {
+      headers: { authorization: "Bearer test-key" },
+    },
+  });
+}
+
+async function startTestHttpServer(
+  validateCredential = async (credential) => ({
+    credential,
+    principal: `test:${credential}`,
+  })
+) {
+  const httpApp = createHttpApp({ validateCredential });
+  const httpServer = await new Promise((resolve, reject) => {
+    const server = httpApp.app.listen(0, "127.0.0.1", () => resolve(server));
+    server.on("error", reject);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Test HTTP server did not expose a TCP address");
+  }
+
+  return {
+    url: new URL(`http://127.0.0.1:${address.port}/mcp`),
+    async close() {
+      await new Promise((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+      await httpApp.close();
+    },
+  };
+}
+
+function rawHttpRequest(url, { method, headers, body }) {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method,
+        headers,
+      },
+      (response) => {
+        response.resume();
+        response.on("end", () => resolve(response));
+      }
+    );
+    request.on("error", reject);
+    request.end(body);
+  });
+}


### PR DESCRIPTION
## Summary

- upgrade from the MCP TypeScript SDK v1 package to the v2 server/client/node packages
- serve MCP `2026-07-28` over stateless HTTP while retaining the SDK's stateless fallback for 2025-era clients
- validate credentials on every HTTP exchange and add Host-header rebinding protection
- retain the v0.4 `search`/`fetch` compatibility, structured output schemas, OAuth metadata, and registry manifests
- bump the package and registry metadata to `0.5.0` and require Node.js 20+

## Impact

Remote MCP requests no longer depend on an `Mcp-Session-Id`, sticky routing, or an in-memory session map. Existing 2025-era Streamable HTTP clients continue through the stateless legacy path. Local npm/stdio consumers need Node.js 20 or newer.

## Validation

- `npm test` — 9/9 passing
- official MCP Conformance scenarios: `server-initialize`, `ping`, `tools-list`, `resources-list`, and `dns-rebinding-protection` — all passing
- modern HTTP pinned to `2026-07-28`, legacy HTTP fallback, and modern stdio integration tests passing
- `npm pack --dry-run` — 21 expected files, including `server.json` and the `fetch` implementation
- package, Official MCP Registry manifest, and LobeHub manifest all report `0.5.0`
- `npm audit --audit-level=high` exits successfully; npm reports two moderate transitive `@hono/node-server` advisories with no fix currently available
