### PR TITLE
Serve robots.txt so crawlers skip the transport host

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -128,6 +128,17 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
     res.redirect(301, target.toString());
   });
 
+  // /mcp is a transport endpoint that answers unauthenticated crawlers with
+  // 401, so search engines gain nothing from walking this host. Keep the OAuth
+  // discovery documents reachable for agents.
+  app.get("/robots.txt", (_req, res) => {
+    res
+      .type("text/plain")
+      .send(
+        ["User-agent: *", "Disallow: /", "Allow: /.well-known/", ""].join("\n")
+      );
+  });
+
   const protectedResourceMetadata = {
     resource: MCP_RESOURCE,
     authorization_servers: [AUTHORIZATION_SERVER],

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -221,6 +221,22 @@ test("rejects DNS rebinding attempts before MCP handling", async (context) => {
   assert.equal(validationCalls, 0);
 });
 
+test("tells crawlers to skip the transport host", async (context) => {
+  const testServer = await startTestHttpServer();
+
+  context.after(() => testServer.close());
+
+  const response = await fetch(new URL("/robots.txt", testServer.url));
+
+  assert.equal(response.status, 200);
+
+  const body = await response.text();
+
+  assert.match(body, /^User-agent: \*$/m);
+  assert.match(body, /^Disallow: \/$/m);
+  assert.match(body, /^Allow: \/\.well-known\/$/m);
+});
+
 test("rejects retired or unknown tools before making an API request", async () => {
   await assert.rejects(
     handleToolCall("reasoning", {}),


### PR DESCRIPTION
## 背景

FAT-881 的收录复查里，Google Search Console 把 `mcp.search1api.com/mcp` 归在 **Blocked due to other 4xx**（最近抓取 2026-07-15）。实测这个端点对未认证请求返回 401，爬虫走过去拿不到任何可索引的东西，但抓取动作照样消耗抓取预算 —— 同期 `/proxies/static-isp`、`/free-search-api` 这些真实产品页至今一次都没被 Google 抓过。

`mcp.search1api.com/robots.txt` 目前是 404（`Cannot GET /robots.txt`）。

服务根路径 `/` 已经 301 跳到 `www.search1api.com/docs/integrations/mcp`，GSC 里那条 404 记录（2026-07-03 抓取）是跳转上线前的历史数据。

## 改动

在 `createHttpApp` 里提供 `/robots.txt`：

```
User-agent: *
Disallow: /
Allow: /.well-known/
```

保留 `/.well-known/*`，因为 agent 要在那里解析 OAuth protected-resource 和 authorization-server 文档。

## 验证

`npm test`（全量）：10 tests / 10 pass，含新增的 robots.txt 用例。

## 部署说明

**本 PR 不含部署。**

## 相关

同批的 `api.search1api.com` 改动在 monorepo：fatwang2/search1api#109。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
