### PR TITLE
Automate Official MCP Registry publishing

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,56 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify release metadata and npm package
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          SERVER_VERSION=$(node -p "require('./server.json').version")
+          NPM_VERSION=$(npm view "search1api-mcp@$PACKAGE_VERSION" version)
+
+          test "$SERVER_VERSION" = "$PACKAGE_VERSION"
+          test "$NPM_VERSION" = "$PACKAGE_VERSION"
+
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            test "$RELEASE_TAG" = "v$PACKAGE_VERSION"
+          fi
+
+      - name: Install pinned mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+        run: |
+          set -euo pipefail
+          curl -fsSLo mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/$MCP_PUBLISHER_VERSION/mcp-publisher_linux_amd64.tar.gz"
+          echo "$MCP_PUBLISHER_SHA256  mcp-publisher.tar.gz" | sha256sum --check
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Validate Registry metadata
+        run: ./mcp-publisher validate
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary

- add a dedicated Official MCP Registry publishing workflow
- publish automatically when a GitHub Release is created
- support manual dispatch to backfill the already-released `v0.5.1`
- authenticate with GitHub OIDC instead of personal access tokens
- pin `mcp-publisher` to `v1.8.0` and verify the official SHA-256 digest

## Why

The npm and GitHub Release workflow does not update the Official MCP Registry,
so its Search1API record remains on `0.4.0`. Interactive GitHub device
authentication also failed to authorize the organization namespace reliably.
Repository OIDC proves the publishing repository directly and does not require a
long-lived personal or Registry secret.

## Safety checks

- workflow permissions default to `contents: read`
- only the publish job receives `id-token: write`
- package, `server.json`, and npm versions must match before publishing
- release-triggered runs verify the GitHub Release tag
- the downloaded publisher binary is pinned and checksum-verified
- `mcp-publisher validate` runs before authentication and publication

## Validation

- YAML parses successfully
- `server.json` validates against the production Registry
- npm `search1api-mcp@0.5.1` is already available
- publisher version and digest match the official MCP Registry `v1.8.0` release
