### PR TITLE
Release MCP v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ If you prefer to run the server locally, use Node.js 20 or newer with npx — no
 For self-hosted HTTP deployments behind a proxy, add any internal hostnames
 that reach the Node.js process to the comma-separated `MCP_ALLOWED_HOSTS`
 environment variable. `mcp.search1api.com` and localhost addresses are allowed
-by default.
+by default. Browser-based clients that send an `Origin` header must also have
+their trusted origin hostnames added to the comma-separated
+`MCP_ALLOWED_ORIGINS` variable. Requests from server-side MCP clients normally
+omit `Origin` and do not require an entry.
 
 ## Tools
 
@@ -184,6 +187,7 @@ Get trending topics from popular platforms.
 
 ## Version History
 
+- v0.5.2: MCP `Origin` validation now runs before request parsing and authentication; self-hosted HTTP deployments can configure trusted browser origins with `MCP_ALLOWED_ORIGINS`
 - v0.5.1: Documentation, LobeHub manifest, and MCP Registry metadata synchronized; `robots.txt` served on the transport host
 - v0.5.0: MCP 2026-07-28 support with automatic protocol negotiation; stateless compatibility for 2025-era HTTP clients; request-level authentication
 - v0.4.0: Structured output schemas, OAuth security schemes, safety annotations, and Official MCP Registry metadata

--- a/README_zh.md
+++ b/README_zh.md
@@ -127,7 +127,9 @@ npx skills add superagents-lab/search1api-cli
 
 自行部署 HTTP 服务并使用反向代理时，请通过逗号分隔的
 `MCP_ALLOWED_HOSTS` 环境变量添加会到达 Node.js 进程的内部主机名。
-默认允许 `mcp.search1api.com` 和 localhost 地址。
+默认允许 `mcp.search1api.com` 和 localhost 地址。会发送 `Origin` 请求头的
+浏览器客户端还需要通过逗号分隔的 `MCP_ALLOWED_ORIGINS` 添加可信来源的
+主机名。服务端 MCP 客户端通常不会发送 `Origin`，因此不需要额外配置。
 
 ## 工具
 
@@ -182,6 +184,7 @@ npx skills add superagents-lab/search1api-cli
 
 ## 版本历史
 
+- v0.5.2: MCP `Origin` 校验提前到请求解析和认证之前执行；自行托管的 HTTP 部署可通过 `MCP_ALLOWED_ORIGINS` 配置信任的浏览器来源
 - v0.5.1: 同步文档、LobeHub manifest 与 MCP Registry 元数据；传输域名提供 `robots.txt`
 - v0.5.0: 支持 MCP 2026-07-28 与自动协议协商；通过无状态回退兼容 2025 版本 HTTP 客户端；改为请求级认证
 - v0.4.0: 结构化输出 schema、OAuth 安全声明、只读安全注解和官方 MCP Registry 元数据

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fatwang2-search1api-mcp",
   "name": "Search1API MCP Server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "Search1API",
   "authorUrl": "https://github.com/superagents-lab",
   "category": "web-search",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search1api-mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search1api-mcp",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search1api-mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "mcpName": "io.github.superagents-lab/search1api",
   "description": "A Model Context Protocol (MCP) server that provides search and crawl functionality using Search1API",
   "private": false,

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/superagents-lab/search1api-mcp",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "search1api-mcp",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/http.ts
+++ b/src/http.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import type { Server as HttpServer } from "node:http";
 import {
   hostHeaderValidation,
+  originValidation,
   toNodeHandler,
 } from "@modelcontextprotocol/node";
 import {
@@ -40,6 +41,7 @@ export type CredentialValidator = (
 export type HttpAppOptions = {
   validateCredential?: CredentialValidator;
   allowedHostnames?: string[];
+  allowedOriginHostnames?: string[];
 };
 
 export type Search1ApiHttpApp = {
@@ -96,7 +98,10 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
   const credentialValidator = options.validateCredential ?? validateCredential;
   const allowedHostnames =
     options.allowedHostnames ?? configuredAllowedHostnames();
+  const allowedOriginHostnames =
+    options.allowedOriginHostnames ?? configuredAllowedOriginHostnames();
   const validateHost = hostHeaderValidation(allowedHostnames);
+  const validateOrigin = originValidation(allowedOriginHostnames);
 
   const mcpHandler = createMcpHandler(
     ({ authInfo }) => createMcpServer(authInfo?.token),
@@ -164,6 +169,13 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
     );
   });
 
+  app.use("/mcp", (req, res, next) => {
+    if (!validateOrigin(req, res)) {
+      return;
+    }
+    next();
+  });
+
   app.use(express.json());
 
   app.all("/mcp", async (req, res) => {
@@ -195,6 +207,23 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
 
 function configuredAllowedHostnames(): string[] {
   const configured = (process.env.MCP_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((hostname) => hostname.trim())
+    .filter(Boolean);
+
+  return [
+    ...new Set([
+      "mcp.search1api.com",
+      "localhost",
+      "127.0.0.1",
+      "[::1]",
+      ...configured,
+    ]),
+  ];
+}
+
+function configuredAllowedOriginHostnames(): string[] {
+  const configured = (process.env.MCP_ALLOWED_ORIGINS ?? "")
     .split(",")
     .map((hostname) => hostname.trim())
     .filter(Boolean);

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -203,13 +203,74 @@ test("rejects DNS rebinding attempts before MCP handling", async (context) => {
       authorization: "Bearer test-key",
       "content-type": "application/json",
       host: "attacker.example",
-      origin: "https://attacker.example",
     },
     body: "{}",
   });
 
   assert.equal(response.statusCode, 403);
   assert.equal(validationCalls, 0);
+});
+
+test("rejects untrusted Origins before authentication", async (context) => {
+  let validationCalls = 0;
+  const testServer = await startTestHttpServer(async (credential) => {
+    validationCalls += 1;
+    return { credential, principal: `test:${credential}` };
+  });
+
+  context.after(() => testServer.close());
+
+  const response = await discoverRequest(testServer.url, {
+    origin: "https://attacker.example",
+  });
+  const malformedResponse = await rawHttpRequest(testServer.url, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-key",
+      "content-type": "application/json",
+      origin: "https://attacker.example",
+    },
+    body: "{",
+  });
+
+  assert.equal(response.status, 403);
+  assert.equal(malformedResponse.statusCode, 403);
+  assert.equal(validationCalls, 0);
+});
+
+test("allows non-browser MCP requests without an Origin", async (context) => {
+  let validationCalls = 0;
+  const testServer = await startTestHttpServer(async (credential) => {
+    validationCalls += 1;
+    return { credential, principal: `test:${credential}` };
+  });
+
+  context.after(() => testServer.close());
+
+  const response = await discoverRequest(testServer.url);
+
+  assert.equal(response.status, 200);
+  assert.equal(validationCalls, 1);
+});
+
+test("allows explicitly trusted Origins", async (context) => {
+  let validationCalls = 0;
+  const testServer = await startTestHttpServer(
+    async (credential) => {
+      validationCalls += 1;
+      return { credential, principal: `test:${credential}` };
+    },
+    { allowedOriginHostnames: ["trusted.example"] }
+  );
+
+  context.after(() => testServer.close());
+
+  const response = await discoverRequest(testServer.url, {
+    origin: "https://trusted.example",
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(validationCalls, 1);
 });
 
 test("tells crawlers to skip the transport host", async (context) => {
@@ -267,9 +328,10 @@ async function startTestHttpServer(
   validateCredential = async (credential) => ({
     credential,
     principal: `test:${credential}`,
-  })
+  }),
+  options = {}
 ) {
-  const httpApp = createHttpApp({ validateCredential });
+  const httpApp = createHttpApp({ validateCredential, ...options });
   const httpServer = await new Promise((resolve, reject) => {
     const server = httpApp.app.listen(0, "127.0.0.1", () => resolve(server));
     server.on("error", reject);
@@ -288,6 +350,35 @@ async function startTestHttpServer(
       await httpApp.close();
     },
   };
+}
+
+function discoverRequest(url, { origin } = {}) {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-key",
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-protocol-version": "2026-07-28",
+      "mcp-method": "server/discover",
+      ...(origin ? { origin } : {}),
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "server/discover",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientInfo": {
+            name: "search1api-origin-test",
+            version: "1.0.0",
+          },
+          "io.modelcontextprotocol/clientCapabilities": {},
+        },
+      },
+    }),
+  });
 }
 
 function rawHttpRequest(url, { method, headers, body }) {


### PR DESCRIPTION
## Summary
- validate Origin on /mcp before JSON parsing and authentication
- add MCP_ALLOWED_ORIGINS for trusted browser clients in self-hosted deployments
- bump npm, MCP Registry, and LobeHub metadata to 0.5.2

## Verification
- npm test (13/13 passed)
- npm pack --dry-run
- npm audit --audit-level=high
- release metadata consistency check