### PR TITLE
[FAT-1163] Prepare OAuth issuer domain cutover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Search1API Configuration
 # Get your API key from https://www.search1api.com/?utm_source=mcp
-SEARCH1API_KEY=your_api_key_here 
+SEARCH1API_KEY=your_api_key_here
+# Keep the legacy issuer until the coordinated Clerk cutover.
+OAUTH_AUTHORIZATION_SERVER=https://clerk.search1api.com

--- a/src/http.ts
+++ b/src/http.ts
@@ -18,7 +18,8 @@ import { formatError, log } from "./utils.js";
 
 const API_BASE_URL =
   process.env.SEARCH1API_API_URL || "https://api.search1api.com";
-const AUTHORIZATION_SERVER = "https://clerk.search1api.com";
+const DEFAULT_AUTHORIZATION_SERVER = "https://clerk.search1api.com";
+const OAUTH_DISCOVERY_CACHE_CONTROL = "public, max-age=60, s-maxage=60";
 const MCP_RESOURCE = "https://mcp.search1api.com/mcp";
 const MCP_RESOURCE_METADATA =
   "https://mcp.search1api.com/.well-known/oauth-protected-resource/mcp";
@@ -40,6 +41,7 @@ export type CredentialValidator = (
 
 export type HttpAppOptions = {
   validateCredential?: CredentialValidator;
+  authorizationServer?: string;
   allowedHostnames?: string[];
   allowedOriginHostnames?: string[];
 };
@@ -96,6 +98,11 @@ export async function validateCredential(
 export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
   const app = express();
   const credentialValidator = options.validateCredential ?? validateCredential;
+  const authorizationServer = normalizeAuthorizationServer(
+    options.authorizationServer ??
+      process.env.OAUTH_AUTHORIZATION_SERVER ??
+      DEFAULT_AUTHORIZATION_SERVER
+  );
   const allowedHostnames =
     options.allowedHostnames ?? configuredAllowedHostnames();
   const allowedOriginHostnames =
@@ -148,7 +155,7 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
   // exchange; this resource does not require any resource-specific scope.
   const protectedResourceMetadata = {
     resource: MCP_RESOURCE,
-    authorization_servers: [AUTHORIZATION_SERVER],
+    authorization_servers: [authorizationServer],
     bearer_methods_supported: ["header"],
     resource_documentation: "https://www.search1api.com/auth.md",
   };
@@ -159,15 +166,20 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
       "/.well-known/oauth-protected-resource/mcp",
     ],
     (_req, res) => {
-      res.type("application/json").json(protectedResourceMetadata);
+      res
+        .set("Cache-Control", OAUTH_DISCOVERY_CACHE_CONTROL)
+        .type("application/json")
+        .json(protectedResourceMetadata);
     }
   );
 
   app.get("/.well-known/oauth-authorization-server", (_req, res) => {
-    res.redirect(
-      302,
-      `${AUTHORIZATION_SERVER}/.well-known/oauth-authorization-server`
-    );
+    res
+      .set("Cache-Control", OAUTH_DISCOVERY_CACHE_CONTROL)
+      .redirect(
+        302,
+        `${authorizationServer}/.well-known/oauth-authorization-server`
+      );
   });
 
   app.use("/mcp", (req, res, next) => {
@@ -204,6 +216,25 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
     mcpHandler,
     close: () => mcpHandler.close(),
   };
+}
+
+function normalizeAuthorizationServer(value: string): string {
+  const url = new URL(value.trim());
+  const isHttpsOrigin =
+    url.protocol === "https:" &&
+    !url.username &&
+    !url.password &&
+    url.pathname === "/" &&
+    !url.search &&
+    !url.hash;
+
+  if (!isHttpsOrigin) {
+    throw new Error(
+      "OAUTH_AUTHORIZATION_SERVER must be a valid HTTPS origin"
+    );
+  }
+
+  return url.origin;
 }
 
 function configuredAllowedHostnames(): string[] {

--- a/tests/tools.test.mjs
+++ b/tests/tools.test.mjs
@@ -202,7 +202,57 @@ test("does not advertise OIDC session scopes as MCP resource scopes", async (con
 
   assert.equal(response.status, 200);
   assert.equal(metadata.resource, "https://mcp.search1api.com/mcp");
+  assert.deepEqual(metadata.authorization_servers, [
+    "https://clerk.search1api.com",
+  ]);
+  assert.equal(
+    response.headers.get("cache-control"),
+    "public, max-age=60, s-maxage=60"
+  );
   assert.equal("scopes_supported" in metadata, false);
+});
+
+test("supports a coordinated OAuth issuer cutover", async (context) => {
+  const testServer = await startTestHttpServer(undefined, {
+    authorizationServer: "https://clerk.s1.dev/",
+  });
+
+  context.after(() => testServer.close());
+
+  const metadataResponse = await fetch(
+    new URL("/.well-known/oauth-protected-resource/mcp", testServer.url)
+  );
+  const metadata = await metadataResponse.json();
+  assert.deepEqual(metadata.authorization_servers, ["https://clerk.s1.dev"]);
+
+  const redirectResponse = await fetch(
+    new URL("/.well-known/oauth-authorization-server", testServer.url),
+    { redirect: "manual" }
+  );
+  assert.equal(redirectResponse.status, 302);
+  assert.equal(
+    redirectResponse.headers.get("location"),
+    "https://clerk.s1.dev/.well-known/oauth-authorization-server"
+  );
+  assert.equal(
+    redirectResponse.headers.get("cache-control"),
+    "public, max-age=60, s-maxage=60"
+  );
+});
+
+test("rejects invalid OAuth authorization server origins", () => {
+  for (const authorizationServer of [
+    "http://clerk.s1.dev",
+    "https://user:password@clerk.s1.dev",
+    "https://clerk.s1.dev/oauth",
+    "https://clerk.s1.dev?tenant=search1api",
+    "https://clerk.s1.dev#oauth",
+  ]) {
+    assert.throws(
+      () => createHttpApp({ authorizationServer }),
+      /must be a valid HTTPS origin/
+    );
+  }
 });
 
 test("rejects DNS rebinding attempts before MCP handling", async (context) => {


### PR DESCRIPTION
## Summary

- parameterize hosted MCP OAuth discovery with OAUTH_AUTHORIZATION_SERVER
- preserve https://clerk.search1api.com as the safe default before cutover
- validate the configured issuer as a credential-free HTTPS origin
- keep token validation unchanged while updating metadata and compatibility redirects
- cache discovery responses for 60 seconds

## How to review

1. Start with issuer normalization and precedence in src/http.ts.
2. Follow the configured issuer through both protected-resource metadata routes and the compatibility discovery redirect.
3. Confirm the default remains the legacy Clerk issuer.
4. Review the cutover and invalid-origin tests.

## Cutover

Merge and deploy this preparation while OAUTH_AUTHORIZATION_SERVER remains omitted or points to https://clerk.search1api.com. After the Clerk domain switch is verified, set OAUTH_AUTHORIZATION_SERVER=https://clerk.s1.dev on the hosted MCP service and redeploy. No MCP DNS change is required.

## Verification

- npm test: 16/16 passed
- TypeScript build passed
- git diff --check passed
- branch is one commit ahead and zero behind main
- read-only idiom/security review found no blocker

Linear: FAT-1163