### PR TITLE
feat: 发布 MCP server card；旧域名换成 s1.dev (v0.5.4)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -5,9 +5,9 @@
   "description": "Web search, news, page crawl, sitemap, and trending topics via Search1API.",
   "author": {
     "name": "Search1API",
-    "url": "https://www.search1api.com"
+    "url": "https://s1.dev"
   },
-  "homepage": "https://www.search1api.com",
+  "homepage": "https://s1.dev",
   "repository": "https://github.com/superagents-lab/search1api-mcp",
   "license": "MIT",
   "keywords": [

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Search1API Configuration
-# Get your API key from https://www.search1api.com/?utm_source=mcp
+# Get your API key from https://s1.dev/?utm_source=mcp
 SEARCH1API_KEY=your_api_key_here
 # Clerk issuer advertised by OAuth discovery.
 OAUTH_AUTHORIZATION_SERVER=https://clerk.s1.dev

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [中文文档](./README_zh.md)
 
-The official MCP server for [Search1API](https://www.search1api.com/?utm_source=mcp) — web search, news, page retrieval, sitemap discovery, and trending topics in one API.
+The official MCP server for [Search1API](https://s1.dev/?utm_source=mcp) — web search, news, page retrieval, sitemap discovery, and trending topics in one API.
 
 ## Authentication
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -5,7 +5,7 @@
 
 [English](./README.md)
 
-[Search1API](https://www.search1api.com/?utm_source=mcp) 官方 MCP 服务 — 一个 API 搞定搜索、新闻、爬虫等能力。
+[Search1API](https://s1.dev/?utm_source=mcp) 官方 MCP 服务 — 一个 API 搞定搜索、新闻、爬虫等能力。
 
 ## 认证
 

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fatwang2-search1api-mcp",
   "name": "Search1API MCP Server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "Search1API",
   "authorUrl": "https://github.com/superagents-lab",
   "category": "web-search",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search1api-mcp",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search1api-mcp",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search1api-mcp",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "mcpName": "io.github.superagents-lab/search1api",
   "description": "A Model Context Protocol (MCP) server that provides search and crawl functionality using Search1API",
   "private": false,
@@ -48,7 +48,7 @@
     "type": "git",
     "url": "git+https://github.com/superagents-lab/search1api-mcp.git"
   },
-  "homepage": "https://github.com/superagents-lab/search1api-mcp#readme",
+  "homepage": "https://s1.dev",
   "bugs": {
     "url": "https://github.com/superagents-lab/search1api-mcp/issues"
   },

--- a/plugin.json
+++ b/plugin.json
@@ -5,9 +5,9 @@
   "description": "Web search, news, page crawl, sitemap, and trending topics via Search1API.",
   "author": {
     "name": "Search1API",
-    "url": "https://www.search1api.com"
+    "url": "https://s1.dev"
   },
-  "homepage": "https://www.search1api.com",
+  "homepage": "https://s1.dev",
   "repository": "https://github.com/superagents-lab/search1api-mcp",
   "license": "MIT",
   "keywords": [

--- a/src/http.ts
+++ b/src/http.ts
@@ -14,6 +14,8 @@ import {
 } from "@modelcontextprotocol/server";
 import express from "express";
 import { createMcpServer } from "./server.js";
+import { ALL_TOOLS } from "./tools/index.js";
+import { PACKAGE_VERSION } from "./version.js";
 import { formatError, log } from "./utils.js";
 
 const API_BASE_URL =
@@ -131,7 +133,7 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
   // The service root is documentation, not an MCP transport endpoint. Keep
   // query parameters so bookmarked campaign/support links remain attributable.
   app.get("/", (req, res) => {
-    const target = new URL("https://www.search1api.com/docs/integrations/mcp");
+    const target = new URL("https://s1.dev/docs/integrations/mcp");
     for (const [key, value] of Object.entries(req.query)) {
       if (typeof value === "string") {
         target.searchParams.append(key, value);
@@ -157,7 +159,7 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
     resource: MCP_RESOURCE,
     authorization_servers: [authorizationServer],
     bearer_methods_supported: ["header"],
-    resource_documentation: "https://www.search1api.com/auth.md",
+    resource_documentation: "https://s1.dev/auth.md",
   };
 
   app.get(
@@ -172,6 +174,48 @@ export function createHttpApp(options: HttpAppOptions = {}): Search1ApiHttpApp {
         .json(protectedResourceMetadata);
     }
   );
+
+  // /mcp answers unauthenticated callers with 401 by design, so this card is
+  // the only pre-connection description of the server. It is built from
+  // ALL_TOOLS, so the advertised tool surface cannot drift from the real one.
+  app.get("/.well-known/mcp/server-card.json", (_req, res) => {
+    res
+      .set("Cache-Control", OAUTH_DISCOVERY_CACHE_CONTROL)
+      .type("application/json")
+      .json({
+        name: "Search1API",
+        version: PACKAGE_VERSION,
+        description:
+          "Remote MCP server for Search1API. Exposes live web search, news, page reading, sitemap discovery, and trending topics as tools for AI agents.",
+        serverUrl: MCP_RESOURCE,
+        tools: ALL_TOOLS.map((tool) => ({
+          name: tool.name,
+          title: tool.title,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          annotations: tool.annotations,
+        })),
+        serverInfo: {
+          name: "Search1API",
+          title: "Search1API MCP",
+          version: PACKAGE_VERSION,
+        },
+        protocolVersion: "2025-06-18",
+        transport: { type: "streamable-http", endpoint: MCP_RESOURCE },
+        capabilities: { tools: {} },
+        authentication: {
+          type: "oauth2",
+          protectedResourceMetadata: MCP_RESOURCE_METADATA,
+          authorizationServerMetadata: `${authorizationServer}/.well-known/oauth-authorization-server`,
+          legacyApiKey: {
+            supported: true,
+            method: "Authorization: Bearer SEARCH1API_KEY",
+          },
+        },
+        homepage: "https://s1.dev",
+        documentation: "https://s1.dev/docs",
+      });
+  });
 
   app.get("/.well-known/oauth-authorization-server", (_req, res) => {
     res


### PR DESCRIPTION
## 1. `/.well-known/mcp/server-card.json`

`/mcp` 对未认证调用返回 401 是**刻意设计**（见 `robots.txt` 附近的注释：不让搜索引擎爬这个 host）。副作用是 agent 在建立连接之前，没有任何途径了解这个服务提供什么工具。

新增一个 server card 端点，**从 `ALL_TOOLS` 生成**：

- advertised 的工具面不可能与真实工具面漂移
- 不需要为了让 agent 预览而放宽 `/mcp` 的鉴权

字段用扁平形状（`name` / `version` / `description` / `serverUrl` / `tools[]`），这是扫描器和 agent 做连接前发现时读的形状；`serverInfo` / `transport` 等 MCP 原生嵌套形状同时保留，已有客户端不受影响。

`s1.dev/.well-known/mcp/server-card.json` 会读取这份卡片再对外提供（1h revalidate + 静态兜底），所以两边只有一个事实来源。

本地起服务实测：返回 5 个工具及其完整 `inputSchema`，未认证可读。

## 2. 旧域名

`www.search1api.com` 已于 2026-08 迁走，以下位置仍指向它：

- **protected resource metadata 的 `resource_documentation`** —— 这是 OAuth 发现链路上 agent 会跟进去的地址，最要紧的一处
- 服务根路径的文档重定向目标
- `plugin.json`、`.cursor-plugin/plugin.json` 的 `url` 与 `homepage`（agent host 直接读）
- `package.json` `homepage`、`README`、`README_zh`、`.env.example`

`api.` / `mcp.` / `status.` 三个子域是活的，**一处未动**（保留 27 处引用）。

## 版本

0.5.3 → 0.5.4，`package-lock.json` 已同步。build、16 项测试、`sync:manifest` 均通过。

合并后发 release 触发 release workflow。

## 相关

- fatwang2/search1api#171（主仓库，s1.dev 侧读取这份 server card）
- search1api-cli#8、search1api-js、search1api-python

🤖 Generated with [Claude Code](https://claude.com/claude-code)